### PR TITLE
Feature 131

### DIFF
--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -227,7 +227,7 @@ class WandBHandler:
                 extra.pop("num_bins", extra.pop("bins", 64))
             )  # TODO: check if bins is needed
 
-            logs = {}
+            logs: dict[str, Any] = {}
 
             try:
                 if not isinstance(payload, (Sequence, np.ndarray)):

--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -7,9 +7,9 @@ from collections.abc import Mapping, Sequence
 from typing import Any, ClassVar, Literal, TypeAlias, cast
 
 import numpy as np
+import wandb
 from typing_extensions import Self
 
-import wandb
 from goggles.media import create_numpy_vector_field_visualization
 from goggles.types import Kind
 
@@ -227,7 +227,7 @@ class WandBHandler:
                 extra.pop("num_bins", extra.pop("bins", 64))
             )  # TODO: check if bins is needed
 
-            logs: dict[str, Any] = {}
+            logs = {}
 
             try:
                 if not isinstance(payload, (Sequence, np.ndarray)):
@@ -279,7 +279,7 @@ class WandBHandler:
                 return
             mode_literal = cast(Literal["vorticity", "magnitude"], mode)
 
-            logs: dict[str, Any] = {}
+            logs = {}
             items = (
                 payload.items()
                 if isinstance(payload, Mapping)

--- a/goggles/_core/routing.py
+++ b/goggles/_core/routing.py
@@ -32,10 +32,6 @@ class GogglesClient:
     """Client for the Goggles EventBus.
 
     Wraps a portal.Client to provide event emission.
-
-    Attributes:
-        futures: Snapshot of futures currently managed by the underlying
-            portal client (auto-cleaned on completion).
     """
 
     _client: portal.Client

--- a/goggles/config.py
+++ b/goggles/config.py
@@ -181,3 +181,105 @@ def save_configuration(config: PrettyConfig, file_path: str) -> None:
     yaml = YAML(typ="safe", pure=True)
     with open(file_path, "w", encoding="utf-8") as f:
         yaml.dump(dict(config), f)
+
+
+def parse_value(raw: str) -> Any:
+    """Convert a CLI string into an appropriate Python value.
+
+    Args:
+        raw: Raw CLI value.
+
+    Returns:
+        Parsed Python value.
+
+    """
+    lowered = raw.lower()
+
+    if lowered in {"true", "false"}:
+        result: Any = lowered == "true"
+        return result
+
+    if lowered == "none":
+        result = None
+        return result
+
+    try:
+        result = int(raw)
+        return result
+    except ValueError:
+        pass
+
+    try:
+        result = float(raw)
+        return result
+    except ValueError:
+        pass
+
+    result = raw
+    return result
+
+
+def apply_overrides(
+    config: PrettyConfig,
+    overrides: list[str],
+) -> PrettyConfig:
+    """Apply CLI overrides to an existing configuration.
+
+    Overrides must follow the syntax:
+
+        key.subkey=value
+
+    Args:
+        config: Configuration object to modify.
+        overrides: List of CLI override expressions.
+
+    Returns:
+        Updated PrettyConfig instance.
+
+    Raises:
+        ValueError: If the override format is invalid.
+        KeyError: If the key path does not exist or is invalid.
+    """
+    for item in overrides:
+        if "=" not in item:
+            raise ValueError(
+                f"Invalid override '{item}'. Expected format key.subkey=value."
+            )
+
+        key_path, raw_value = item.split("=", 1)
+        keys = key_path.split(".")
+        value = parse_value(raw_value)
+
+        d = config
+
+        for k in keys[:-1]:
+            if k not in d:
+                raise KeyError(
+                    f"Invalid override '{key_path}': key '{k}' does not exist."
+                )
+
+            if not isinstance(d[k], dict):
+                raise KeyError(
+                    f"Invalid override '{key_path}': "
+                    f"'{k}' is not a nested dictionary."
+                )
+
+            d = d[k]
+
+        final_key = keys[-1]
+
+        if final_key not in d:
+            raise KeyError(
+                f"Invalid override '{key_path}': "
+                f"final key '{final_key}' does not exist."
+            )
+
+        if isinstance(d[final_key], dict):
+            raise KeyError(
+                f"Invalid override '{key_path}': "
+                "cannot overwrite a dictionary node."
+            )
+
+        d[final_key] = value
+
+    return config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,14 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-from goggles.config import PrettyConfig, load_configuration
+import pytest
+
+from goggles.config import (
+    PrettyConfig,
+    apply_overrides,
+    load_configuration,
+    parse_value,
+)
 
 
 @dataclass(frozen=True)
@@ -194,3 +201,171 @@ def test_private_fields_not_serialized_yaml_json_roundtrip(
     assert "_secret" not in loaded_json, (
         "JSON output should not contain private fields."
     )
+
+
+# =========================================================
+# CLI override utilities
+# =========================================================
+
+
+def test_parse_value_bool() -> None:
+    """Boolean strings should convert to bool."""
+    # Arrange
+    raw_true = "true"
+    raw_false = "false"
+
+    # Act
+    result_true = parse_value(raw_true)
+    result_false = parse_value(raw_false)
+
+    # Assert
+    assert result_true is True
+    assert result_false is False
+
+
+def test_parse_value_none() -> None:
+    """String 'none' should convert to None."""
+    # Arrange
+    raw = "none"
+
+    # Act
+    result = parse_value(raw)
+
+    # Assert
+    assert result is None
+
+
+def test_parse_value_int() -> None:
+    """Integer strings should convert to int."""
+    # Arrange
+    raw = "42"
+
+    # Act
+    result = parse_value(raw)
+
+    # Assert
+    assert result == 42
+    assert isinstance(result, int)
+
+
+def test_parse_value_float() -> None:
+    """Float strings should convert to float."""
+    # Arrange
+    raw = "1e-3"
+
+    # Act
+    result = parse_value(raw)
+
+    # Assert
+    assert isinstance(result, float)
+    assert result == pytest.approx(1e-3)
+
+
+def test_parse_value_string() -> None:
+    """Non-numeric strings should remain strings."""
+    # Arrange
+    raw = "experiment"
+
+    # Act
+    result = parse_value(raw)
+
+    # Assert
+    assert result == "experiment"
+
+
+def test_apply_overrides() -> None:
+    """Apply multiple overrides to a configuration."""
+    # Arrange
+    config = PrettyConfig(
+        {
+            "training": {
+                "lr": 0.001,
+                "epochs": 10,
+            },
+            "seed": 0,
+        }
+    )
+
+    overrides = [
+        "training.lr=0.02",
+        "training.epochs=20",
+        "seed=42",
+    ]
+
+    # Act
+    result = apply_overrides(config, overrides)
+
+    # Assert
+    assert result["training"]["lr"] == pytest.approx(0.02)
+    assert result["training"]["epochs"] == 20
+    assert result["seed"] == 42
+
+
+def test_override_invalid_format() -> None:
+    """Overrides without '=' should raise ValueError."""
+    # Arrange
+    config = PrettyConfig({"training": {"lr": 0.001}})
+    overrides = ["training.lr"]
+
+    # Act / Assert
+    with pytest.raises(ValueError):
+        apply_overrides(config, overrides)
+
+
+def test_override_invalid_key_path() -> None:
+    """Overriding a missing key path should raise KeyError."""
+    # Arrange
+    config = PrettyConfig({"training": {"lr": 0.001}})
+    overrides = ["model.lr=0.01"]
+
+    # Act / Assert
+    with pytest.raises(KeyError):
+        apply_overrides(config, overrides)
+
+
+def test_override_dict_node_forbidden() -> None:
+    """Overwriting a dictionary node should raise KeyError."""
+    # Arrange
+    config = PrettyConfig({"training": {"lr": 0.001}})
+    overrides = ["training=5"]
+
+    # Act / Assert
+    with pytest.raises(KeyError):
+        apply_overrides(config, overrides)
+
+
+def test_override_non_dict_intermediate() -> None:
+    """Traversing through a non-dict node should raise KeyError."""
+    # Arrange
+    config = PrettyConfig({"training": {"lr": 0.001}})
+    overrides = ["training.lr.value=1"]
+
+    # Act / Assert
+    with pytest.raises(KeyError):
+        apply_overrides(config, overrides)
+
+
+def test_override_type_parsing() -> None:
+    """Overrides should parse values into correct Python types."""
+    # Arrange
+    config = PrettyConfig(
+        {
+            "training": {"lr": 0.001},
+            "seed": 0,
+            "use_gpu": False,
+        }
+    )
+
+    overrides = [
+        "training.lr=0.1",
+        "seed=42",
+        "use_gpu=true",
+    ]
+
+    # Act
+    result = apply_overrides(config, overrides)
+
+    # Assert
+    assert isinstance(result["training"]["lr"], float)
+    assert isinstance(result["seed"], int)
+    assert isinstance(result["use_gpu"], bool)


### PR DESCRIPTION
### Summary
Add utilities to parse and apply configuration overrides.

### Changes
- Implement `parse_value` and `apply_overrides` in `goggles/config.py`
- Add tests for the new functionality in `tests/test_config.py`

### Maintenance
- Fix a `pydoclint` issue in `GogglesClient` docstring
- Minor lint/type fixes in the W&B handler

All tests and pre-commit checks pass locally.