### PR TITLE
feat(agents): introduce agent development docs and tighten tooling

### DIFF
--- a/.agent/rules/rules.md
+++ b/.agent/rules/rules.md
@@ -1,0 +1,30 @@
+---
+trigger: always_on
+---
+
+# Project rules
+
+For complete project rules, see [docs/standards/](../../docs/standards/).
+
+## Quick links
+
+- [Environment & tooling](../../docs/standards/environment-tooling.md)
+- [Code quality gates](../../docs/standards/code-quality.md)
+- [Linting & formatting](../../docs/standards/linting-formatting.md)
+- [Typing & docstrings](../../docs/standards/typing-docstrings.md)
+- [Code clarity](../../docs/standards/code-clarity.md)
+- [Exploration & validation](../../docs/standards/exploration-validation.md)
+- [JAX & numerical code](../../docs/standards/jax-numerical.md)
+- [Testing policy](../../docs/standards/testing.md)
+- [API design](../../docs/standards/api-design.md)
+- [Version control](../../docs/standards/version-control.md)
+- [Code organization](../../docs/standards/code-organization.md)
+- [Change scope](../../docs/standards/change-scope.md)
+
+## Quick start
+
+1. **Orientation**: [docs/workflows/orientation.md](../../docs/workflows/orientation.md) if unfamiliar with the codebase.
+2. **Architecture**: Read [docs/guides/architecture.md](../../docs/guides/architecture.md) before making changes.
+3. **Workflows**: Choose from [docs/workflows/](../../docs/workflows/).
+
+See [docs/index.md](../../docs/index.md) for complete documentation index.

--- a/.agent/workflows/api-validation.md
+++ b/.agent/workflows/api-validation.md
@@ -1,0 +1,5 @@
+---
+description: External API validation and integration
+---
+
+Follow the workflow in [docs/workflows/api-validation.md](../../docs/workflows/api-validation.md).

--- a/.agent/workflows/bugfix.md
+++ b/.agent/workflows/bugfix.md
@@ -1,0 +1,5 @@
+---
+description: Bugfix or regression workflow
+---
+
+Follow the workflow in [docs/workflows/bugfix.md](../../docs/workflows/bugfix.md).

--- a/.agent/workflows/docs.md
+++ b/.agent/workflows/docs.md
@@ -1,0 +1,5 @@
+---
+description: Documentation-only change
+---
+
+Follow the workflow in [docs/workflows/docs.md](../../docs/workflows/docs.md).

--- a/.agent/workflows/feature.md
+++ b/.agent/workflows/feature.md
@@ -1,0 +1,5 @@
+---
+description: Standard feature implementation
+---
+
+Follow the workflow in [docs/workflows/feature.md](../../docs/workflows/feature.md).

--- a/.agent/workflows/orientation.md
+++ b/.agent/workflows/orientation.md
@@ -1,0 +1,5 @@
+---
+description: Quick orientation before making changes
+---
+
+Follow the workflow in [docs/workflows/orientation.md](../../docs/workflows/orientation.md).

--- a/.agent/workflows/refactor.md
+++ b/.agent/workflows/refactor.md
@@ -1,0 +1,5 @@
+---
+description: Code refactoring without behavior change
+---
+
+Follow the workflow in [docs/workflows/refactor.md](../../docs/workflows/refactor.md).

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,60 @@
+# Goggles development
+
+All documentation is centralized in `docs/`. Claude will discover what it needs based on your task.
+
+## Essential commands
+
+```bash
+# Test
+uv run pytest
+
+# Lint and format (commit-stage checks)
+uv run pre-commit run --all-files
+
+# Type check + full test suite (pre-push stage)
+uv run pre-commit run --all-files --hook-stage pre-push
+
+# Add dependency
+uv add <package>              # Runtime
+uv add --dev <package>        # Dev dependency
+uv add --optional jax <pkg>   # Optional JAX extra
+uv add --optional wandb <pkg> # Optional W&B extra
+```
+
+## Workflows
+
+When starting a task, refer to the appropriate workflow from `docs/workflows/`:
+
+- **Feature**: see `docs/workflows/feature.md`
+- **Bugfix**: see `docs/workflows/bugfix.md`
+- **Refactor**: see `docs/workflows/refactor.md`
+- **API validation**: see `docs/workflows/api-validation.md`
+- **Documentation**: see `docs/workflows/docs.md`
+- **Orientation (first time)**: see `docs/workflows/orientation.md`
+
+## Standards
+
+All code must follow standards in `docs/standards/`:
+
+- Always use `uv run` for commands (never assume global installs)
+- Run all quality gates before finishing (pre-commit + pre-push hooks must pass)
+- Write tests first (TDD approach)
+- Google-style docstrings, types in signatures only
+- Keep base install light: JAX/W&B are optional extras
+- Never import from `goggles/_core/` outside the package itself
+
+## Architecture
+
+See `docs/guides/architecture.md` for codebase structure and subsystem responsibilities.
+
+## Key project-specific rules
+
+- **Do not push to remote without explicit user authorization.**
+- **Commit messages**: follow the `.gitmessage` template (Conventional Commits).
+- **Allowed uppercase local vars**: `B`, `T`, `H`, `W`, `N` (tensor dimensions).
+- **No guarded imports** (`try/except ImportError`): express optionality via extras in `pyproject.toml` instead.
+- **Public vs private**: symbols not in `goggles.__all__` are internal and can be moved/renamed freely.
+
+## Documentation
+
+For comprehensive documentation, see `docs/index.md`.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 exclude: ^pyproject\.toml$
 
 repos:
-  # Ruff: lint (will fail on violations like unused/incorrect noqa, similar to pyright)
+  # Ruff: lint + format (single source of truth; rules live in pyproject.toml)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.1
     hooks:
       - id: ruff
         stages: [pre-commit, pre-push]
-        # Removed --fix to make it fail on violations (including RUF100)
-        # Run 'uv run ruff check --fix .' manually to auto-fix if needed
+        # No --fix: fail loudly on violations (including RUF100).
+        # Run `uv run ruff check --fix .` manually to auto-fix.
 
       - id: ruff-format
         stages: [pre-commit, pre-push]
 
-  # Pydoclint: docstring linting (refer to pyproject.toml for configuration)
+  # Pydoclint: docstring/signature consistency (see pyproject.toml)
   - repo: local
     hooks:
       - id: pydoclint
@@ -23,7 +23,15 @@ repos:
         types: [python]
         stages: [pre-commit, pre-push]
 
-  # Type checking (BasedPyright)
+  # Generic hygiene
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  # Expensive checks: only run on push (type-checking and the test suite).
   - repo: local
     hooks:
       - id: basedpyright
@@ -32,12 +40,12 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
-        stages: [pre-commit, pre-push]
+        stages: [pre-push]
 
-  # Generic hygiene
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: check-yaml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
+      - id: pytest
+        name: pytest
+        entry: uv run pytest
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-push]

--- a/docs/agents/implementer.md
+++ b/docs/agents/implementer.md
@@ -1,0 +1,30 @@
+---
+description: Task implementer for features and fixes
+---
+
+You are an implementation agent for the Goggles repository.
+
+## Source of truth
+
+- Standards: [docs/standards/](../standards/)
+- Workflows: [docs/workflows/](../workflows/)
+- Architecture: [docs/guides/architecture.md](../guides/architecture.md)
+- Documentation index: [docs/index.md](../index.md)
+
+## When implementing work
+
+1. Pick and follow the appropriate workflow from `docs/workflows/`.
+2. Keep changes minimal and logically scoped. Never widen scope without
+   asking.
+3. Run all quality gates before considering work complete:
+   - `uv run pre-commit run --all-files`
+   - `uv run pre-commit run --all-files --hook-stage pre-push`
+4. Update docs/docstrings for public API behavior changes.
+5. Use commit messages that follow the `.gitmessage` template.
+
+## Preferred tools
+
+- `uv run` for commands (do not assume global installs)
+- `pytest` for testing
+- `ruff` + `ruff-format` for linting/formatting
+- `basedpyright` for type checking

--- a/docs/agents/reviewer.md
+++ b/docs/agents/reviewer.md
@@ -1,0 +1,29 @@
+---
+description: Strict code reviewer for this repository
+---
+
+You are a code reviewer for the Goggles repository.
+
+## Source of truth
+
+- Standards: [docs/standards/](../standards/)
+- Architecture: [docs/guides/architecture.md](../guides/architecture.md)
+- Documentation index: [docs/index.md](../index.md)
+
+## When reviewing changes, check for
+
+- Correctness and logical consistency
+- Test coverage (unit and integration where applicable)
+- Compliance with standards in `docs/standards/`
+- API simplicity and scope control (avoid over-engineering; new public
+  symbols are a commitment)
+- Docstring quality (Google-style, type info in signatures only)
+- Logical commit scope
+- Back-compat: is any symbol in `goggles.__all__` renamed, removed, or
+  semantically changed without a version bump?
+
+## Review preference
+
+- Suggest small, incremental diffs
+- Prioritize actionable findings
+- Keep comments concise and specific

--- a/docs/guides/agent-development.md
+++ b/docs/guides/agent-development.md
@@ -1,0 +1,209 @@
+# Agent-driven development guide
+
+This guide explains how to use the Goggles documentation and workflows with different agentic systems (Claude Code, GitHub Copilot, custom agents, ...).
+
+## Overview
+
+Goggles is optimized for agent-driven development. All rules, workflows, and procedures are centralized in the `docs/` folder, and compatibility layers in `.agent/`, `.github/`, and `.claude/` reference them.
+
+## Infrastructure at a glance
+
+| System | Primary entry point | Always-on rules behavior | Workflow selection | Canonical rule source |
+|---|---|---|---|---|
+| Claude Code | `.claude/CLAUDE.md` | Loads project instructions from `.claude/CLAUDE.md`, which references `docs/standards/` | User prompt references `docs/workflows/*` | `docs/standards/` |
+| GitHub Copilot | `.github/copilot-instructions.md` | Instruction file enforces orientation and links standards/workflows | Prompt and task context plus linked workflow docs | `docs/standards/` |
+| Antigravity / other slash-command agents | `.agent/rules/rules.md` + `.agent/workflows/*` | `.agent/rules/rules.md` is `always_on` and points to standards | Slash commands or workflow wrappers in `.agent/workflows/*` | `docs/standards/` |
+| Custom agents | Integrator-defined | Must be configured to consume project entry points and `docs/` | Integrator-defined | `docs/standards/` |
+
+Interpretation: wrappers define how agents discover and trigger behavior; `docs/standards/` remains the single source of truth for policy.
+
+## Using with Claude Code
+
+### Entry point
+
+Claude Code reads its configuration from:
+1. `.claude/CLAUDE.md` (this project's rules) - **Start here**
+2. `docs/` (full documentation)
+3. `.agent/` (legacy workflows mirror)
+
+### Quick start
+
+When working with Claude Code:
+
+```
+User: "I want to add a handler for MLflow. Please follow the feature workflow."
+
+Claude Code will:
+1. Read .claude/CLAUDE.md for project context
+2. Reference docs/workflows/feature.md for step-by-step procedure
+3. Follow docs/standards/ for code quality rules
+4. Return results
+```
+
+### Configuration files
+
+- **`.claude/CLAUDE.md`** - Main rules file with links to all documentation
+- **`.claude/settings.local.json`** - Local permissions (not agent rules)
+
+### Running workflows
+
+You can reference workflows directly:
+- Feature work: See [docs/workflows/feature.md](../workflows/feature.md)
+- Bug fixes: See [docs/workflows/bugfix.md](../workflows/bugfix.md)
+
+## Using with GitHub Copilot
+
+### Entry point
+
+GitHub Copilot reads its configuration from `.github/copilot-instructions.md` (optional; create when/if Copilot is used).
+
+### How it works
+
+The copilot-instructions.md file is a thin wrapper that references:
+- `docs/standards/` for all rules
+- `docs/workflows/` for step-by-step procedures
+- `docs/guides/` for architecture and contribution guides
+
+## Using with slash-command agents (Antigravity, Cursor, ...)
+
+### Entry point
+
+Wrapper agents read from:
+1. `.agent/rules/rules.md` (project rules wrapper)
+2. `.agent/workflows/` (workflow references)
+
+### How it works
+
+- **`.agent/rules/rules.md`** references `docs/standards/` for all coding standards.
+- **`.agent/workflows/`** contains thin wrappers that point to `docs/workflows/`.
+- **Slash commands** like `/feature`, `/bugfix`, `/orientation` provide quick access to workflows.
+
+Available slash commands (mapped to `.agent/workflows/*.md`):
+- `/feature` - Standard feature implementation
+- `/bugfix` - Bug fix workflow
+- `/refactor` - Code refactoring
+- `/api-validation` - External API exploration
+- `/docs` - Documentation changes
+- `/orientation` - Project orientation
+
+## Using with custom agents
+
+### Integration pattern
+
+If you're building a custom agent for Goggles:
+
+1. **Read `.claude/CLAUDE.md`** to understand the project
+2. **Reference `docs/index.md`** as your documentation hub
+3. **Use `docs/workflows/`** for step-by-step procedures
+4. **Check `docs/standards/`** for specific rules
+
+## Workflow reference
+
+All workflows follow the same structure:
+
+### Feature workflow
+**Use when:** Implementing a standard feature without external API exploration
+- Location: [docs/workflows/feature.md](../workflows/feature.md)
+- Process: Write tests -> implement -> verify -> document
+
+### Bugfix workflow
+**Use when:** Fixing a reported bug
+- Location: [docs/workflows/bugfix.md](../workflows/bugfix.md)
+- Process: Reproduce -> fix -> verify -> document
+
+### Refactor workflow
+**Use when:** Improving structure without changing behavior
+- Location: [docs/workflows/refactor.md](../workflows/refactor.md)
+- Process: Understand current structure -> refactor -> verify behavior unchanged
+
+### API validation workflow
+**Use when:** Exploring external APIs or uncertain about design
+- Location: [docs/workflows/api-validation.md](../workflows/api-validation.md)
+- Process: Create scratch script -> validate -> document findings -> clean up
+
+### Documentation workflow
+**Use when:** Making documentation-only changes
+- Location: [docs/workflows/docs.md](../workflows/docs.md)
+- Process: Edit docs -> verify links -> commit
+
+### Orientation workflow
+**Use when:** First time working on the project, or returning after a long absence
+- Location: [docs/workflows/orientation.md](../workflows/orientation.md)
+- Process: Read architecture -> skim public API -> run tests -> pick workflow
+
+## Standards quick reference
+
+When implementing, keep these standards in mind:
+
+### Tools
+- **Always use `uv run`** for all commands
+- See [docs/standards/environment-tooling.md](../standards/environment-tooling.md)
+
+### Quality gates
+- Must pass `uv run pre-commit run --all-files` (commit stage: ruff, pydoclint, hygiene)
+- Must pass `uv run pre-commit run --all-files --hook-stage pre-push` (adds basedpyright + pytest)
+- See [docs/standards/code-quality.md](../standards/code-quality.md)
+
+### Code style
+- Google-style docstrings with descriptions only
+- Type hints in function signatures, not docstrings
+- See [docs/standards/typing-docstrings.md](../standards/typing-docstrings.md)
+
+### Testing
+- Use pytest; parametrize over repeating tests
+- Include descriptive assert messages
+- See [docs/standards/testing.md](../standards/testing.md)
+
+### JAX / numerical (optional history subsystem)
+- Prefer JAX inside `goggles/history/`
+- Make randomness explicit via PRNGKey; keep tests deterministic
+- See [docs/standards/jax-numerical.md](../standards/jax-numerical.md)
+
+## Architecture reference
+
+For understanding the codebase structure:
+
+- **Full guide:** [docs/guides/architecture.md](architecture.md)
+- **Key components:**
+  - `goggles/` - Public API
+  - `goggles/_core/` - Implementation detail
+  - `goggles/_core/integrations/` - Handlers (console, local storage, W&B)
+  - `goggles/history/` - Optional JAX history subsystem
+  - `tests/` - Test suite
+  - `examples/` - Runnable demos
+
+## Making changes to documentation
+
+If you need to update project rules or workflows:
+
+1. **Make changes in `docs/`** - This is the single source of truth
+2. **All agents will automatically see the updates**
+3. **No need to update multiple files** - The wrappers in `.agent/`, `.github/`, and `.claude/` reference the central docs
+
+This ensures consistency across all agentic systems.
+
+## Troubleshooting
+
+### "I don't know what workflow to use"
+Start with [docs/workflows/orientation.md](../workflows/orientation.md) to understand the project, then pick the workflow that matches your task.
+
+### "Where do I find the architecture?"
+See [docs/guides/architecture.md](architecture.md) for a complete overview of the codebase structure and responsibilities.
+
+### "What rules apply to my code?"
+Check [docs/standards/](../standards/) for the specific rule you're unsure about. Each file covers one topic.
+
+## For project maintainers
+
+When updating project standards:
+
+1. Update the relevant file in `docs/standards/`
+2. No need to update `.agent/rules/rules.md` or `.claude/CLAUDE.md` unless the change concerns the agent-discovery mechanism itself
+3. All agents will automatically see the changes
+4. Consider updating `docs/index.md` if you add new standards
+
+When creating new workflows:
+
+1. Create the file in `docs/workflows/`
+2. Add a link to `docs/index.md`
+3. Add a thin wrapper in `.agent/workflows/` so slash-command agents can trigger it

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -1,0 +1,152 @@
+# Architecture
+
+This page is the map contributors and agents should consult before making
+changes. It covers the package layout, what is public vs internal, and
+the main subsystems. User-facing usage lives in the top-level
+[README](../../README.md).
+
+## Package layout
+
+```
+goggles/
+|-- __init__.py        # Public API: re-exports + runtime patches
+|-- config.py          # YAML config loading/saving (PrettyConfig)
+|-- filters.py         # Built-in signal filters (median, std-reject, ...)
+|-- media.py           # Image/video/vector-field helpers
+|-- shutdown.py        # GracefulShutdown utility
+|-- types.py           # Event, Kind, Image, Video, VectorField, Metrics
+|-- validation.py      # Configuration validation helpers
+|-- history/           # Optional JAX device-resident history buffers
+|   |-- buffer.py
+|   |-- spec.py
+|   |-- types.py
+|   `-- utils.py
+`-- _core/             # Implementation detail; do not import outside
+    |-- logger.py            # CoreTextLogger / CoreGogglesLogger impls
+    |-- routing.py           # GogglesClient / EventBus routing
+    |-- decorators.py        # @timeit / @trace_on_error impls
+    `-- integrations/
+        |-- console.py        # ConsoleHandler
+        |-- storage.py        # LocalStorageHandler
+        `-- wandb.py          # WandBHandler (W&B extra)
+```
+
+### Public vs internal
+
+Anything reachable from `goggles.__all__` is **public**. The current
+public surface is (see [goggles/__init__.py](../../goggles/__init__.py)):
+
+- Log levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`
+- Loggers: `get_logger`, `TextLogger`, `GogglesLogger`
+- Event model: `Event`, `Kind`, `Metrics`, `Image`, `Video`,
+  `Vector`, `VectorField`
+- Handlers: `ConsoleHandler`, `LocalStorageHandler`, `WandBHandler`
+- Bus management: `attach`, `detach`, `register_handler`
+- Decorators: `timeit`, `trace_on_error`
+- Config: `PrettyConfig`, `load_configuration`, `save_configuration`
+- Shutdown: `GracefulShutdown`
+- Submodule: `filters`
+
+Everything else is **internal**. Moving, renaming, or deleting
+internal symbols does not require a deprecation cycle. Public changes
+do (see [api-design.md](../standards/api-design.md)).
+
+## Subsystems
+
+### 1. Logger & bus routing (`_core/logger.py`, `_core/routing.py`)
+
+Goggles maintains a **process-wide EventBus** that routes events to
+attached handlers. The user-facing entry points are `get_logger()` and
+`attach()` in `goggles/__init__.py`.
+
+- Loggers carry a `scope` (free-form string, default `global`). Events
+  are routed to handlers attached to matching scopes.
+- Scope matching supports hierarchy via dot notation: a handler on
+  `global` also receives events from `global.run1`.
+- Events include logs (text) and structured data (`scalar`, `image`,
+  `video`, `vector_field`, `histogram`, ...).
+
+### 2. Event model (`types.py`)
+
+`Event`, `Kind`, and the payload types (`Image`, `Video`,
+`VectorField`, `Metrics`, `Vector`) define the wire format between
+loggers and handlers. They are serializable so they can cross
+process boundaries via portal/TinyROS.
+
+### 3. Handlers / integrations (`_core/integrations/`)
+
+Each handler implements the `Handler` protocol (see
+`goggles/__init__.py`). Built-in handlers:
+
+- **ConsoleHandler**: colored terminal output.
+- **LocalStorageHandler**: JSON-Lines on disk.
+- **WandBHandler** (`wandb` extra): Weights & Biases integration with
+  multi-run grouping.
+
+Adding a new handler: subclass an existing handler or implement the
+`Handler` protocol directly, then register it with
+`register_handler()` so it can be serialized for transport across the
+bus.
+
+### 4. Transport & resilience (`goggles/__init__.py`, top)
+
+Goggles uses the `portal` library for inter-process RPC. The module
+import patches portal in three places to prevent memory leaks and
+hangs:
+
+1. `SendBuffer.send` -> propagate `ConnectionResetError`.
+2. `ServerSocket._loop` -> disconnect clients on write errors.
+3. `ClientSocket._loop` -> clear send queue on disconnect.
+4. `Client.call` -> honor `GOGGLES_TRANSPORT_TIMEOUT` while waiting
+   for in-flight requests.
+
+These patches are temporary. Remove them once upstream portal fixes
+land (see the `# NOTE` block at the top of the file).
+
+### 5. History subsystem (`history/`, optional)
+
+Device-resident JAX buffers for metrics tracked during long GPU runs.
+Activated via the `jax` extras group. Pure-functional,
+JIT-safe updates; no host-device sync during `update_history`.
+
+See [jax-numerical.md](../standards/jax-numerical.md) for the
+conventions that apply inside this subsystem.
+
+### 6. Config (`config.py`)
+
+`load_configuration` / `save_configuration` provide YAML IO with
+`PrettyConfig` for readable serialization. `validation.py` hosts
+schema helpers used by handlers with structured config (for example
+the WandB handler).
+
+### 7. Shutdown (`shutdown.py`)
+
+`GracefulShutdown` is the user-facing context manager for clean
+teardown. Internally, `goggles.finish()` calls into the bus to flush
+and close all handlers with a configurable timeout
+(`GOGGLES_SHUTDOWN_TIMEOUT`).
+
+## Cross-cutting concerns
+
+- **Environment variables**:
+  - `GOGGLES_PORT` (default `2304`) -- bus TCP port.
+  - `GOGGLES_HOST` (default `localhost`) -- bus hostname.
+  - `GOGGLES_ASYNC` (default `1`) -- async emit mode.
+  - `GOGGLES_TRANSPORT_TIMEOUT` (default `30.0s`) -- client call timeout.
+  - `GOGGLES_SHUTDOWN_TIMEOUT` (default `5.0s`) -- shutdown timeout.
+  - `GOGGLES_SUPPRESS_CONNECTIVITY_LOGS` (default `1`) -- silence
+    "Dropping message" chatter from portal.
+
+- **Tests mirror this layout** (`tests/core/`, `tests/core/integrations/`,
+  `tests/history/`, `tests/benchmark/`).
+
+## Where to make changes
+
+| Change | Where |
+|---|---|
+| New handler / integration | `goggles/_core/integrations/<name>.py`, register in `goggles/_core/integrations/__init__.py`, re-export from `goggles/__init__.py`. |
+| New filter | `goggles/filters.py` (public module). |
+| New logger method | Update the `TextLogger` / `DataLogger` / `GogglesLogger` Protocols in `goggles/__init__.py`, then `_core/logger.py`. |
+| New config helper | `goggles/config.py` (keep the YAML-focused surface small). |
+| New history buffer op | `goggles/history/buffer.py` + types in `goggles/history/types.py`. |
+| Transport workaround | `goggles/__init__.py` under the existing monkey-patch block; leave a removal NOTE. |

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -1,0 +1,13 @@
+# Contributing (quick pointer)
+
+The full contributing guide lives at the repository root in
+[CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+For day-to-day agent work, prefer these doc hub entries instead:
+
+- [docs/index.md](../index.md) -- documentation index.
+- [docs/workflows/](../workflows/) -- step-by-step procedures.
+- [docs/standards/](../standards/) -- per-topic coding standards.
+- [docs/guides/architecture.md](architecture.md) -- codebase map.
+- [docs/guides/agent-development.md](agent-development.md) -- how
+  Claude Code, GitHub Copilot, and other agents discover the rules.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,79 @@
+# Goggles documentation hub
+
+This is the single source of truth for all Goggles development documentation. Start here.
+
+User-facing usage lives in the top-level [README](../README.md). This hub is aimed at contributors and agents working on the code.
+
+---
+
+## Guides
+
+| Document | What it covers |
+|---|---|
+| [contributing.md](guides/contributing.md) | Development setup, branch workflow, PR preparation, commit style |
+| [agent-development.md](guides/agent-development.md) | Using Goggles with Claude Code, GitHub Copilot, and custom agents |
+| [architecture.md](guides/architecture.md) | Package layout, public surface, and subsystem responsibilities |
+
+---
+
+## Standards
+
+One file per topic -- all code must satisfy these:
+
+| Standard | Topic |
+|---|---|
+| [environment-tooling.md](standards/environment-tooling.md) | Always use `uv run`; virtual-env discipline |
+| [code-quality.md](standards/code-quality.md) | Pre-commit gates, quality checklist |
+| [code-clarity.md](standards/code-clarity.md) | Naming, function length, indentation, readability |
+| [code-organization.md](standards/code-organization.md) | Module layout and ownership rules |
+| [typing-docstrings.md](standards/typing-docstrings.md) | Modern type hints (PEP 585/604), Google-style docstrings |
+| [testing.md](standards/testing.md) | TDD, Arrange/Act/Assert, coverage, hypothesis |
+| [api-design.md](standards/api-design.md) | Public API contracts, backward compatibility |
+| [change-scope.md](standards/change-scope.md) | What belongs in a single PR |
+| [version-control.md](standards/version-control.md) | Commit messages, branch naming |
+| [linting-formatting.md](standards/linting-formatting.md) | Ruff, pydoclint, basedpyright config |
+| [exploration-validation.md](standards/exploration-validation.md) | Scratch scripts and API validation |
+| [jax-numerical.md](standards/jax-numerical.md) | Optional JAX history subsystem conventions |
+
+---
+
+## Workflows
+
+Step-by-step procedures for common tasks:
+
+| Workflow | When to use |
+|---|---|
+| [orientation.md](workflows/orientation.md) | First time on the project, or returning after a long absence |
+| [feature.md](workflows/feature.md) | Implementing a new feature (TDD approach) |
+| [bugfix.md](workflows/bugfix.md) | Fixing a reported bug |
+| [refactor.md](workflows/refactor.md) | Improving structure without changing behavior |
+| [api-validation.md](workflows/api-validation.md) | Exploring external APIs or uncertain design |
+| [docs.md](workflows/docs.md) | Documentation-only changes |
+
+---
+
+## Agent personas
+
+| Persona | Purpose |
+|---|---|
+| [agents/implementer.md](agents/implementer.md) | Guidance for the implementing agent role |
+| [agents/reviewer.md](agents/reviewer.md) | Guidance for the reviewing agent role |
+
+---
+
+## Quick reference
+
+```bash
+# Run tests
+uv run pytest
+
+# Lint and format (runs on commit)
+uv run pre-commit run --all-files
+
+# Full pre-push checks (type-check + tests)
+uv run pre-commit run --all-files --hook-stage pre-push
+
+# Add a dependency
+uv add <package>          # runtime
+uv add --dev <package>    # dev-only
+```

--- a/docs/standards/api-design.md
+++ b/docs/standards/api-design.md
@@ -1,0 +1,22 @@
+# API design & over-engineering
+
+## Principles
+
+- **Do not over-optimize or over-generalize early.**
+- Prefer **simple, explicit APIs** with a single clear usage.
+- Goggles is a *library*. Every new public symbol becomes part of the
+  supported surface; prefer keeping helpers private until a second caller
+  justifies exposure.
+
+## Timing
+
+Generalization should come **after real use cases**, not before.
+
+## Public surface
+
+- The public API is re-exported from [goggles/__init__.py](../../goggles/__init__.py).
+- Anything under `goggles/_core/` is implementation detail. Do not import
+  from `_core` in examples, docstrings, or user-facing docs.
+- Adding or removing a symbol in `goggles.__all__` is a *breaking change*
+  for downstream projects (fluidscontrol, flowbench, pinet, ...). Flag it
+  clearly in the PR and bump the version per SemVer.

--- a/docs/standards/change-scope.md
+++ b/docs/standards/change-scope.md
@@ -1,0 +1,10 @@
+# Change scope & discipline
+
+## Keeping changes focused
+
+- Keep commits and changes **logically scoped**.
+- Avoid mixing refactors, feature changes, and formatting in the same change.
+- Do not modify tooling rules or tooling policy documents unless the user
+  explicitly asks for that change.
+- Prefer **many small PRs over one large PR**. Goggles is released
+  frequently to PyPI; small PRs ship faster and regress less.

--- a/docs/standards/code-clarity.md
+++ b/docs/standards/code-clarity.md
@@ -1,0 +1,76 @@
+# Comments & code clarity
+
+## Comment philosophy
+
+- **Do not pollute the code with comments explaining reasoning step-by-step.**
+- This applies to inline comments; docstrings are an exception.
+- Comments should explain **why** something is done, not:
+  - what the code does (the code should be readable)
+  - how it does it (that should be clear from implementation)
+
+## Good comment example
+
+```python
+# Keep the writer thread alive until the queue drains; otherwise
+# async handlers may drop events on interpreter shutdown.
+```
+
+## American English
+
+- All prose in this repository uses **American English** spelling.
+- This rule applies to code (comments, docstrings, identifiers, log/error
+  messages) and markdown documentation.
+- Prefer `-ize` / `-ization` over `-ise` / `-isation` (`optimize`,
+  `normalize`, `serialize`).
+- Prefer `-or` over `-our` (`color`, `behavior`, `favor`).
+- Prefer `-er` over `-re` (`center`, `meter`).
+- Examples:
+  - `normalize`, `optimization`, `behavior`, `serialized`, `center`
+  - Not: `normalise`, `optimisation`, `behaviour`, `serialised`, `centre`
+
+## Avoid unnecessary special characters
+
+- Prefer characters that are easily available on a US keyboard. Do not
+  reach for fancy Unicode glyphs when a plain equivalent exists.
+- Standard punctuation (`"`, `'`, etc.) is fine.
+- **Do not use raw Unicode math/Greek/unit symbols** (`pi`, `sigma`, `mu`,
+  `+/-`, `~=`, `<=`, etc.) from the keyboard. In docstrings intended for
+  Sphinx rendering, use LaTeX via ``:math:`...` ``; in runtime-facing
+  strings (logs, prints, CLI output), fall back to plain ASCII.
+- Examples of substitutions to make:
+  - Use `...` instead of the single ellipsis character.
+  - Use `"` and `'` instead of curly/smart quotes.
+  - Use `-` or `--` instead of en/em dashes.
+  - Use `->` instead of arrow glyphs.
+
+## Header and title capitalization
+
+- In markdown documentation **and in docstrings**, **only capitalize the
+  first word** of headers, titles, and docstring section headings.
+- This rule applies to all Markdown files in the repository (including
+  `docs/`, `README.md`, `CONTRIBUTING.md`, PR/issue templates) and to all
+  Python docstrings (including the first-line summary and any
+  in-docstring section headings).
+- Keep proper nouns, library names, and acronyms as needed (for example,
+  `GitHub`, `API`, `JAX`, `NumPy`, `W&B`, `Goggles`).
+- Examples:
+  - `## Handler lifecycle` (not `## Handler Lifecycle`)
+  - `## Logging scope` (not `## Logging Scope`)
+  - `## Type ignore & lint suppressions` (not `## Type Ignore & Lint Suppressions`)
+  - `"""Load a YAML configuration file."""` (not `Load A YAML Configuration File`)
+
+## Markdown link paths
+
+- For links to files or folders in this repository, use **relative paths**.
+- This rule applies to markdown documentation in the repository (for
+  example `docs/`, `README.md`, `CONTRIBUTING.md`).
+- Do not use absolute local paths such as `file:///...`, `/home/...`, or
+  `C:\...`.
+- Do not use repository-internal raw GitHub links
+  (`https://raw.githubusercontent.com/...`) when the target file exists
+  in this repo; use relative links so IDE navigation works.
+- Examples:
+  - `[Code clarity](../standards/code-clarity.md)`
+  - `[Contributing](docs/guides/contributing.md)`
+  - Not: `[Code clarity](file:///home/user/project/docs/standards/code-clarity.md)`
+  - Not: `[Contributing](https://raw.githubusercontent.com/org/repo/main/CONTRIBUTING.md)`

--- a/docs/standards/code-organization.md
+++ b/docs/standards/code-organization.md
@@ -1,0 +1,39 @@
+# Code organization & readability
+
+## Code style
+
+- Prefer **clear, explicit code** over clever or compact code.
+- Avoid introducing new abstractions unless they reduce complexity.
+- Match existing patterns in the codebase before inventing new ones.
+
+## Package layout
+
+| Path | Purpose |
+|---|---|
+| `goggles/` | Public API: top-level modules re-exported from `goggles/__init__.py`. |
+| `goggles/_core/` | Implementation details. Never import from here outside the package. |
+| `goggles/_core/integrations/` | Backend handlers (console, local storage, W&B, ...). |
+| `goggles/history/` | Optional JAX-based device-resident history subsystem. |
+| `tests/` | Unit + benchmark + integration tests; mirror public modules where possible. |
+| `examples/` | Runnable demos that drive the public API. |
+
+## Internal vs public
+
+- Anything not exported from `goggles/__init__.py` is considered internal.
+- Rename or move internal symbols freely. Public symbols require a
+  deprecation + version bump.
+- New public exports must also appear in the relevant docs page and,
+  where applicable, the top-level `README.md`.
+
+## Handler scope naming
+
+Loggers in Goggles carry a scope (for example `global`, `training`,
+`episode_0`). When emitting logger names *inside* the library itself,
+follow these rules:
+
+- Scopes are free-form strings chosen by users, not library code.
+- When the library creates its own logger (for example inside shutdown
+  utilities), use `get_logger(__name__)` so the scope matches the module
+  path under `goggles.`.
+- Do not invent deeper scope hierarchies from within the library; let
+  callers name their own scopes.

--- a/docs/standards/code-quality.md
+++ b/docs/standards/code-quality.md
@@ -1,0 +1,32 @@
+# Code quality gates
+
+All modified code must pass the following quality gates before a task is considered complete.
+
+## Required checks
+
+- **Ruff and Ruff-format must pass** on all modified files (lint + format).
+- **Pydoclint must pass** (Google-style docstring consistency).
+- **BasedPyright must pass** (basic mode).
+- **Pytest must pass** (the full test suite, including benchmarks).
+
+## Running quality gates
+
+Pre-commit splits checks into two stages:
+
+- **`pre-commit` (runs on every `git commit`)**: ruff, ruff-format,
+  pydoclint, generic hygiene. Fast.
+- **`pre-push` (runs on every `git push`)**: basedpyright + pytest on
+  top of the commit-stage checks. Slower, comprehensive.
+
+Before finishing a task, **run both stages**:
+
+```bash
+uv run pre-commit run --all-files
+uv run pre-commit run --all-files --hook-stage pre-push
+```
+
+**A task is NOT complete unless both invocations pass.**
+
+All linting and formatting rules live in `pyproject.toml`. Do not
+override rule selection via CLI flags in pre-commit or scripts.
+Pre-commit controls *when* tools run, not *what* rules apply.

--- a/docs/standards/environment-tooling.md
+++ b/docs/standards/environment-tooling.md
@@ -1,0 +1,44 @@
+# Environment & tooling
+
+## Using uv
+
+- **Always use `uv run`** to execute tools and scripts.
+  - Never assume global installs.
+  - Examples:
+    ```bash
+    uv run python
+    uv run pytest
+    uv run ruff
+    ```
+
+## Managing dependencies
+
+- **Add dependencies with uv (don't edit `pyproject.toml` by hand unless necessary).**
+  - Runtime dependency:
+    ```bash
+    uv add <package>
+    ```
+  - Dev dependency (linters/formatters/type checkers/test tooling):
+    ```bash
+    uv add --dev <package>
+    ```
+
+- **If you add a new external dependency (new import), you must:**
+  1. Add it with `uv add` / `uv add --dev`.
+  2. Place it in the correct extras group if it is optional: `jax` for
+     JAX-backed features, `wandb` for the W&B handler, `dev` for dev
+     tooling only. Goggles keeps the base install light on purpose.
+  3. Ensure the lockfile is updated (`uv lock` if needed).
+  4. Commit both `pyproject.toml` and `uv.lock`.
+
+## Port isolation for multi-process tests
+
+- Goggles uses a shared TCP port (`GOGGLES_PORT`) for inter-process log
+  routing. When starting processes by hand (benchmarks, reproduction
+  scripts, manual experiments), pick a free port rather than reusing a
+  default -- otherwise a lingering server from a previous run will
+  capture the new connection.
+  ```bash
+  GOGGLES_PORT="$(uv run python -c 'import socket; s=socket.socket(); s.bind((\"\", 0)); print(s.getsockname()[1]); s.close()')" \
+      uv run python -m tests.benchmark.benchmark_logger --log-type scalar
+  ```

--- a/docs/standards/exploration-validation.md
+++ b/docs/standards/exploration-validation.md
@@ -1,0 +1,16 @@
+# Exploration, validation, and temporary scripts
+
+## When unsure about design
+
+When unsure about an idea, behavior, or design:
+- **validate it with a temporary script or experiment**
+- do *not* pollute the main codebase with exploratory logic
+
+## After validation
+
+After validation:
+- **delete the temporary code**
+- encode the conclusion in one of:
+  - a concise comment (for local decisions)
+  - a docstring (for API-level behavior)
+  - a document under `docs/` (for important design choices)

--- a/docs/standards/jax-numerical.md
+++ b/docs/standards/jax-numerical.md
@@ -1,0 +1,33 @@
+# JAX & numerical code
+
+Goggles ships an **optional** JAX-based device-resident history subsystem
+under [goggles/history/](../../goggles/history/), exposed via the `jax`
+extras group. Rules in this file apply to that subsystem and any future
+numerical code.
+
+## Framework preferences
+
+- **Prefer JAX** inside the history subsystem.
+- Do not mix ML frameworks (PyTorch, TensorFlow) in the same module.
+- Keep JAX **optional**: base install must not require JAX. Import inside
+  `goggles/history/` is fine; top-level imports of JAX are not.
+
+## Code style
+
+- Write code with **functional style and explicit data flow** where
+  possible. The history subsystem is already pure-functional; new
+  additions should match.
+- Updates to history buffers are JIT-safe: no Python-side state, no host
+  synchronization during update.
+
+## Shape conventions
+
+- Batch-first: tensors are `(B, T, *shape)`.
+- Reserved dimension names in local variables: `B`, `T`, `H`, `W`, `N`.
+
+## Randomness & reproducibility
+
+When randomness is involved:
+- make it explicit via a JAX PRNGKey parameter
+- set seeds at the top of examples/tests
+- keep tests deterministic (no wall-clock RNG seeding inside the subsystem)

--- a/docs/standards/linting-formatting.md
+++ b/docs/standards/linting-formatting.md
@@ -1,0 +1,63 @@
+# Linting & formatting policy
+
+## Configuration
+
+- **All linting and formatting rules live in `pyproject.toml`.**
+  - Do not override rule selection via CLI flags in pre-commit or scripts.
+  - Pre-commit controls *when* tools run, not *what* rules apply.
+
+## Ruff as single source of truth
+
+- **Ruff is the single source of truth** for:
+  - unused variables/imports
+  - import ordering
+  - modern typing syntax
+  - docstring style
+  - low-noise bug patterns
+- **Ruff-format** replaces Black. Do not reintroduce Black.
+
+## Pydoclint
+
+- Pydoclint is enabled **in addition** to Ruff's `D` rules because
+  Ruff does not yet implement the argument-vs-signature consistency
+  checks Pydoclint provides. When Ruff reaches parity, migrate to Ruff
+  only.
+- Pydoclint is configured in `[tool.pydoclint]` in `pyproject.toml`.
+
+## Allowed exceptions
+
+- Allowed uppercase local variable names for tensor/shape dimensions:
+  - `B`, `T`, `H`, `W`, `N` (see `N803`, `N806` ignored rules).
+
+## Import organization
+
+- **Imports must be at the top of the file** by default.
+  - Local imports (inside functions/methods) are allowed **only** to
+    avoid circular dependencies or for specific performance/lazy-loading
+    reasons (for example deferring an optional `jax` import until the
+    history module is actually used).
+  - If a local import is used, it **must** be documented with a comment
+    above it explaining why it's not at the top-level.
+
+### Never guard imports with try/except
+
+Wrap an import in a `try/except` block **only when explicitly instructed**
+to do so.
+
+**Rationale:** Guarded imports hide missing dependencies until the code
+path that uses the symbol is executed, turning a clear
+`ModuleNotFoundError` at startup into a cryptic `AttributeError` deep
+inside a call stack. If a dependency is optional, the optionality must
+be expressed in the project's packaging (an extras group in
+`pyproject.toml`), not silenced in source.
+
+```python
+# Wrong
+try:
+    import jax.numpy as jnp
+except ImportError:
+    jnp = None  # type: ignore[assignment]
+
+# Right (optional JAX handled via the `jax` extra)
+import jax.numpy as jnp
+```

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -1,0 +1,65 @@
+# Testing policy
+
+## Test framework
+
+- **Always use `pytest`** for testing.
+
+## Test structure
+
+- Test directories **mirror `goggles/`** so you can find tests by module path:
+  - `tests/core/` for `goggles/_core/`
+  - `tests/core/integrations/` for `goggles/_core/integrations/`
+  - `tests/history/` for `goggles/history/`
+  - `tests/benchmark/` for performance/regression benchmarks
+- **Keep test files small and focused.** One file per concern or layer --
+  for example `test_api.py`, `test_routing.py`, `test_logger.py`,
+  `test_hang_resilience.py`.
+- Each test file should have a **module-level docstring** explaining
+  what behavior it verifies.
+
+## Test design
+
+- **Functionality-driven tests only.** Test behavior and contracts, not
+  implementation details. Drop tests that just verify a constructor sets
+  an attribute or that a type check fires.
+- Use **multiple small unit tests** rather than one large test.
+- Add **integration tests** (`tests/core/integrations/`) when behavior
+  spans multiple handlers, processes, or the W&B backend.
+
+## Testing best practices
+
+- Prefer `pytest.mark.parametrize` over repeated tests.
+- **Always check `tests/conftest.py`** and subdirectory `conftest.py`
+  files for existing fixtures before adding new ones.
+- **Always include a descriptive message in `assert` statements** to
+  explain what exactly failed and why (for example,
+  `assert x == y, f"Expected {y}, got {x}"`).
+- Use `pytest.mark.skip(reason=...)` for tests that need adaptation,
+  with a clear reason explaining what changed.
+- Resilience / hang-recovery tests use the `resilience` marker. They
+  are slower and may be disabled in fast iterations:
+  `uv run pytest -m "not resilience"`.
+
+## Multi-process tests
+
+- Goggles runs across processes. Tests that spawn subprocesses must use
+  a **unique `GOGGLES_PORT` per test run** (see `conftest.py` fixtures).
+  Never hardcode a port in a test module.
+- Use the `xdist_group` marker to force serial execution inside a group
+  when tests share a port or global state.
+
+## Running tests
+
+```bash
+# Full suite (matches CI and pre-push)
+uv run pytest
+
+# A subsystem
+uv run pytest tests/core/integrations/
+
+# Skip slow/disruptive resilience tests
+uv run pytest -m "not resilience"
+
+# Benchmarks only
+uv run pytest tests/benchmark/
+```

--- a/docs/standards/typing-docstrings.md
+++ b/docs/standards/typing-docstrings.md
@@ -1,0 +1,74 @@
+# Typing & docstrings
+
+## Type information placement
+
+- **Type information belongs in function signatures**, not in docstrings.
+- **Do not include type hints in `Args:` or `Returns:` sections.**
+- Use **Google-style docstrings** with descriptions only.
+- Pydoclint enforces this rule: `arg-type-hints-in-docstring = false`.
+
+## Example
+
+```python
+def save_configuration(config: dict[str, Any], path: str) -> None:
+    """Save a configuration dict to a YAML file.
+
+    Args:
+        config: Configuration to serialize.
+        path: Destination path. Parent directories must exist.
+
+    Raises:
+        FileNotFoundError: If the parent directory does not exist.
+    """
+```
+
+## Type ignore & lint suppressions
+
+- **Never use `type: ignore` comments** without explicitly telling the
+  user first. `pyproject.toml` has `enableTypeIgnoreComments = false` on
+  pyright; adding one will also require changing policy.
+- **Never use `# noqa` for specific rules** without explicitly telling
+  the user first.
+- Both are code debt and should only be used with awareness and
+  acknowledgment.
+
+## Documentation requirements
+
+- All **public functions and classes must be documented**.
+- Private helpers (leading underscore) may omit docstrings if their
+  intent is obvious.
+- Module-level docstrings are encouraged on all files (user-facing
+  modules and tests alike).
+- Docstring ignores configured in ruff:
+  - `D100` (missing module docstring) -- allowed
+  - `D104` (missing package `__init__` docstring) -- allowed
+  - `D105` (missing docstring in magic method) -- allowed
+  - `D107` (missing docstring in `__init__`) -- document at class level instead
+  - All other `D*` rules apply.
+
+## Shell command examples in docstrings
+
+- **Never use doctest syntax (`>>>` / `...`) for shell commands.** `>>>`
+  denotes a Python REPL prompt; using it for shell commands is
+  semantically wrong, breaks copy-paste, and misleads tooling.
+- Use a Sphinx **`.. code-block:: console`** directive with `$` as the
+  shell prompt. This renders correctly in Sphinx and keeps commands
+  copyable as a contiguous block.
+- Use `r"""..."""` (raw docstring) when the block contains backslash
+  line continuations, otherwise `\<newline>` is interpreted as a
+  string-literal line continuation and collapses the lines.
+
+### Example
+
+```python
+r"""Run the benchmark logger against a dedicated port.
+
+Usage:
+
+.. code-block:: console
+
+    $ GOGGLES_PORT=8374 uv run python \
+        -m tests.benchmark.benchmark_logger \
+        --log-type scalar --num-logs 10000
+"""
+```

--- a/docs/standards/version-control.md
+++ b/docs/standards/version-control.md
@@ -1,0 +1,27 @@
+# Version control discipline
+
+## Commit strategy
+
+- **Commit code often**, in small, logically coherent units.
+- Do **not** commit unfinished or broken code.
+- **Always follow the `.gitmessage` template** for commit messages.
+- Configure git once with:
+  ```bash
+  git config commit.template .gitmessage
+  ```
+- Goggles uses [Conventional Commits](https://www.conventionalcommits.org/).
+  The `commit-lint` GitHub Action rejects non-conforming titles.
+
+## Branch workflow
+
+- Feature branches start from `main` (this repo does not currently use a
+  `dev` branch -- see `CONTRIBUTING.md` for the canonical description).
+- Open a PR back to `main`; tooling workflows (code-style, tests) must
+  be green before merge.
+- Squash on merge to keep history linear.
+
+## Remote repository
+
+- **Do not push to remote on behalf of the user.** PRs are opened only
+  when explicitly requested, and never force-pushed without explicit
+  authorization.

--- a/docs/workflows/api-validation.md
+++ b/docs/workflows/api-validation.md
@@ -1,0 +1,40 @@
+---
+description: External API validation and integration
+---
+
+Use when interacting with a new external library API or uncertain behavior (for example a new W&B endpoint, a new transport for the routing layer, or a new JAX feature).
+
+1. **Validate first in a scratch script** (not committed):
+   - Write a small script to confirm the API, edge cases, and expected behavior.
+   - Capture outputs, performance notes, and pitfalls.
+2. Summarize findings in 1-5 bullets (for yourself) and decide the minimal integration.
+3. **Write failing unit tests** in the test suite that define the desired API and expected behavior (based on your scratch script findings).
+4. Run tests to confirm they fail:
+   ```bash
+   uv run pytest
+   ```
+5. Implement the **minimal core change** in `goggles/...` to make the tests pass.
+   - Do not over-generalize or add multiple input modes prematurely.
+6. Run the commit-stage gate:
+   ```bash
+   uv run pre-commit run --all-files
+   ```
+7. Run all tests (including the new ones):
+   ```bash
+   uv run pytest
+   ```
+8. Run the pre-push gate (basedpyright + full test suite):
+   ```bash
+   uv run pre-commit run --all-files --hook-stage pre-push
+   ```
+9. Delete the scratch script. Encode conclusions:
+   - small local rationale -> comment (WHY)
+   - API behavior -> docstring
+   - important design decision -> `docs/` entry (if applicable)
+
+**Done criteria:**
+- `uv run pre-commit run --all-files` passes
+- `uv run pytest` passes
+- `uv run pre-commit run --all-files --hook-stage pre-push` passes
+- No temporary scripts committed
+- Public APIs are documented (without docstring type hints)

--- a/docs/workflows/bugfix.md
+++ b/docs/workflows/bugfix.md
@@ -1,0 +1,19 @@
+---
+description: Bugfix or regression workflow
+---
+
+Use when fixing a bug or preventing a known regression.
+
+1. Write a failing test that reproduces the issue (minimal reproduction).
+2. Implement the fix in the correct module under `goggles/`.
+3. Run all checks:
+   ```bash
+   uv run pre-commit run --all-files
+   uv run pre-commit run --all-files --hook-stage pre-push
+   ```
+4. If the fix changes observable behavior, update docstrings and (if
+   needed) the relevant page in `docs/`.
+
+**Done criteria:**
+- The test fails on old code, passes after the fix
+- All checks pass

--- a/docs/workflows/docs.md
+++ b/docs/workflows/docs.md
@@ -1,0 +1,24 @@
+---
+description: Documentation-only change
+---
+
+Use when updating docstrings, README/docs, or comments.
+
+### Standards
+- Adhere to **Docstring & Typing** rules in [`typing-docstrings.md`](../standards/typing-docstrings.md).
+- Follow **Markdown heading capitalization** in [`code-clarity.md`](../standards/code-clarity.md#header-and-title-capitalization): use sentence case (capitalize only the first word, except proper nouns/acronyms).
+- Follow **Markdown link path rules** in [`code-clarity.md`](../standards/code-clarity.md#markdown-link-paths): use relative links for repository-internal targets.
+- Focus on "why" (rationale) rather than just "what" (implementation).
+
+1. Make doc changes (focus on "why" and "how to use").
+2. Run the commit-stage gate if Python files were touched:
+   ```bash
+   uv run pre-commit run --all-files
+   ```
+3. If docs describe behavior that is testable, ensure tests exist or add them.
+
+**Done criteria:**
+- Docs are consistent with code
+- Markdown headings use sentence-case capitalization
+- Repository-internal links are relative and resolve correctly
+- Any touched code still passes `pre-commit`

--- a/docs/workflows/feature.md
+++ b/docs/workflows/feature.md
@@ -1,0 +1,33 @@
+---
+description: Standard feature implementation
+---
+
+Use for ordinary feature work that doesn't require external API exploration.
+
+1. Define the desired API and behavior by **writing failing unit tests** (and integration tests if the feature spans handlers or processes).
+2. Run tests to confirm they fail:
+   ```bash
+   uv run pytest
+   ```
+3. Identify the ownership module under `goggles/` and implement the **minimal change** to make the tests pass.
+   - Keep new helpers private (leading underscore, `_core/`) unless there is an immediate user need.
+4. Run the commit-stage gate:
+   ```bash
+   uv run pre-commit run --all-files
+   ```
+5. Run tests to confirm they pass:
+   ```bash
+   uv run pytest
+   ```
+6. Run the pre-push gate (basedpyright + full test suite):
+   ```bash
+   uv run pre-commit run --all-files --hook-stage pre-push
+   ```
+7. Add/adjust docstrings and documentation as needed.
+   - Docstrings describe behavior; type info stays in signatures.
+   - If the feature adds a public symbol, update `goggles/__init__.py` and the relevant README/docs section.
+
+**Done criteria:**
+- `uv run pre-commit run --all-files` passes
+- `uv run pre-commit run --all-files --hook-stage pre-push` passes
+- Docs are updated for public surface changes

--- a/docs/workflows/orientation.md
+++ b/docs/workflows/orientation.md
@@ -1,0 +1,39 @@
+---
+description: First-time orientation before making changes
+---
+
+Use when working on the project for the first time, or returning after a long absence. Goal: build a mental model of the system before touching code.
+
+1. **Read the architecture overview.**
+   [`docs/guides/architecture.md`](../guides/architecture.md) covers the package layout, public surface, and the main subsystems (core routing, integrations, history, config, filters).
+
+2. **Skim the public API.**
+   Read [`goggles/__init__.py`](../../goggles/__init__.py) -- every symbol re-exported from there is part of the supported surface and will affect downstream projects if changed.
+
+3. **Review the standards.**
+   Skim [`docs/standards/`](../standards/) before writing code -- in particular
+   [`code-organization.md`](../standards/code-organization.md) (public vs `_core`),
+   [`testing.md`](../standards/testing.md) (multi-process port discipline), and
+   [`linting-formatting.md`](../standards/linting-formatting.md) (no guarded imports).
+
+4. **Confirm the environment works.**
+   Run the test suite:
+   ```bash
+   uv run pytest
+   ```
+   All tests should pass before you write a single line.
+
+5. **Pick the right workflow for your task.**
+
+   | Task | Workflow |
+   |---|---|
+   | New feature | [`feature.md`](feature.md) |
+   | Bug fix | [`bugfix.md`](bugfix.md) |
+   | Refactor | [`refactor.md`](refactor.md) |
+   | External API exploration | [`api-validation.md`](api-validation.md) |
+   | Documentation only | [`docs.md`](docs.md) |
+
+**Done criteria:**
+- You can describe the role of `goggles/_core/routing.py`, `goggles/_core/logger.py`, and `goggles/_core/integrations/` without looking them up.
+- You know whether the code you intend to change is public or internal.
+- `uv run pytest` passes.

--- a/docs/workflows/refactor.md
+++ b/docs/workflows/refactor.md
@@ -1,0 +1,23 @@
+---
+description: Code refactoring without behavior change
+---
+
+Use when improving structure, naming, or internal APIs without changing
+observable outputs.
+
+1. Identify the refactor scope and keep it small and coherent.
+2. Ensure existing tests cover the behavior.
+   - If coverage is weak, add characterization tests first.
+3. Apply the refactor in small steps (prefer multiple local commits).
+4. Run all checks:
+   ```bash
+   uv run pre-commit run --all-files
+   uv run pre-commit run --all-files --hook-stage pre-push
+   ```
+5. Update docstrings only if public APIs changed. Renames of
+   `_core/`-level symbols do not need docs updates.
+
+**Done criteria:**
+- Tests provide confidence behavior didn't change
+- All gates pass
+- No new "convenience" API generalization added during refactor

--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -7,9 +7,9 @@ from collections.abc import Mapping, Sequence
 from typing import Any, ClassVar, Literal, TypeAlias, cast
 
 import numpy as np
-import wandb
 from typing_extensions import Self
 
+import wandb
 from goggles.media import create_numpy_vector_field_visualization
 from goggles.types import Kind
 

--- a/goggles/filters.py
+++ b/goggles/filters.py
@@ -669,6 +669,7 @@ class RangeRejectFilter(_BackendAware):
         return xp.where(valid, data, fallback_value)
 
     def reset(self) -> None:
+        """Reset own state and the fallback filter chain."""
         super().reset()
         self.fallback.reset()
         self._last_valid = None
@@ -783,6 +784,7 @@ class StdRejectFilter(_WindowBufferFilter):
         return self._last_valid
 
     def reset(self) -> None:
+        """Reset own state and the fallback filter chain."""
         super().reset()
         self.fallback.reset()
         self._last_valid = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,16 +108,18 @@ target-version = "py310"
 [tool.ruff.lint]
 # Enable comprehensive rule sets
 select = [
-    "E",     # pycodestyle errors (style/formatting)
-    "W",     # pycodestyle warnings
-    "F",     # pyflakes (logical errors)
-    "UP",    # pyupgrade (modern Python syntax)
-    "I",     # isort (import sorting)
-    "N",     # pep8-naming (naming conventions)
-    "B",     # flake8-bugbear (potential bugs)
-    "PL",    # pylint (code quality)
-    "PGH003",# blanket type: ignore
-    "RUF",   # ruff-specific rules (includes RUF100 for unused noqa)
+    "E",      # pycodestyle errors (style/formatting)
+    "W",      # pycodestyle warnings
+    "W505",   # doc-line-too-long (opt-in, paired with max-doc-length)
+    "F",      # pyflakes (logical errors)
+    "UP",     # pyupgrade (modern Python syntax)
+    "I",      # isort (import sorting)
+    "N",      # pep8-naming (naming conventions)
+    "B",      # flake8-bugbear (potential bugs)
+    "D",      # pydocstyle (Google-style docstrings)
+    "PL",     # pylint (code quality)
+    "PGH003", # blanket type: ignore
+    "RUF",    # ruff-specific rules (includes RUF100 for unused noqa)
 ]
 
 # NOTE: issue #117 tracks removing these "too many" ignores:
@@ -132,13 +134,29 @@ ignore = [
     "PLR0912", # Too many branches
     "PLR0915", # Too many statements
     "PLR0911", # Too many return statements
+    "D100",    # Missing docstring in public module
+    "D104",    # Missing docstring in public package
+    "D105",    # Missing docstring in magic method
+    "D107",    # Missing docstring in __init__ (documented at class level)
 ]
 
 # Ensure unused/incorrect noqa comments are detected (similar to pyright's strictness)
 # RUF100 is already included via "RUF" above, but we want to ensure it's not accidentally ignored
 
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["D", "PLR2004"]  # Tests: no docstring policy, allow magic values
+"examples/*" = ["D"]           # Examples: documented via README/comments
+"**/__init__.py" = ["D"]       # Package stubs often re-export only
+
 [tool.ruff.lint.pep8-naming]
 extend-ignore-names = ["__post_init__"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.pycodestyle]
+max-line-length = 80
+max-doc-length = 80
 
 # Pydoclint configuration
 # Pydoclint is used together with Ruff because

--- a/uv.lock
+++ b/uv.lock
@@ -2,12 +2,22 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version < '3.11' and sys_platform == 'linux'",
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
@@ -53,8 +63,8 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
-    { name = "pandas", version = "1.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
     { name = "pyyaml" },
     { name = "tornado", marker = "sys_platform != 'emscripten'" },
@@ -697,12 +707,22 @@ name = "jax"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "jaxlib", version = "0.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -755,12 +775,22 @@ name = "jaxlib"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
@@ -1326,12 +1356,22 @@ name = "numpy"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/62/ae72ff66c0f1fd959925b4c11f8c2dea61f47f6acaea75a08512cdfe3fed/numpy-2.4.1.tar.gz", hash = "sha256:a1ceafc5042451a858231588a104093474c6a5c57dcc724841f5c888d237d690", size = 20721320, upload-time = "2026-01-10T06:44:59.619Z" }
 wheels = [
@@ -1428,39 +1468,6 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
-    "python_full_version == '3.12.*' and sys_platform == 'linux'",
-    "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
-]
-dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "pytz", marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/4e/bc3163c2f0b2f0728c398cad15e082efaa27e40fa579a0523e98caf10fdf/pandas-1.5.1.tar.gz", hash = "sha256:249cec5f2a5b22096440bd85c33106b6102e0672204abd2d5c014106459804ee", size = 5199286, upload-time = "2022-10-19T06:33:32.246Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/f1/0fea6a6ad6e88f603443a0e9f225f0feafeba4ec899f09846ea7ad5c06e7/pandas-1.5.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0a78e05ec09731c5b3bd7a9805927ea631fe6f6cb06f0e7c63191a9a778d52b4", size = 18519267, upload-time = "2022-10-19T06:28:51.363Z" },
-    { url = "https://files.pythonhosted.org/packages/97/04/e2f55bb7fea442e27a002df165d05e0fcd4c282a3ca0da9f717f021515e8/pandas-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5b0c970e2215572197b42f1cff58a908d734503ea54b326412c70d4692256391", size = 11965694, upload-time = "2022-10-19T06:28:59.836Z" },
-    { url = "https://files.pythonhosted.org/packages/68/49/7244ad35598bd612a4b68a86030d9ed210ff9a9f9def2e67282cce128512/pandas-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f340331a3f411910adfb4bbe46c2ed5872d9e473a783d7f14ecf49bc0869c594", size = 10832761, upload-time = "2022-10-19T06:29:12.143Z" },
-    { url = "https://files.pythonhosted.org/packages/88/ca/d8f52ce9faa3c48f7c5dd2fd7bfb036263d77eb61b1c616679faa25e5f88/pandas-1.5.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8c709f4700573deb2036d240d140934df7e852520f4a584b2a8d5443b71f54d", size = 11361545, upload-time = "2022-10-19T06:29:20.803Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/aa/1ba5c0835aa83af896cdb61df439335f39ca59392aff5fd1a06a152a7aae/pandas-1.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32e3d9f65606b3f6e76555bfd1d0b68d94aff0929d82010b791b6254bf5a4b96", size = 12054467, upload-time = "2022-10-19T06:29:30.578Z" },
-    { url = "https://files.pythonhosted.org/packages/50/15/ce88c13d182c34e73a9bee8665340bff200b175af39fa160d30e6d37f7aa/pandas-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:a52419d9ba5906db516109660b114faf791136c94c1a636ed6b29cbfff9187ee", size = 10354037, upload-time = "2022-10-19T06:29:38.438Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/33/f5d9c0eea8dc9c1d3c49524704d95c81ebcc6f5919698ce6875a3f0c4bdd/pandas-1.5.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:66a1ad667b56e679e06ba73bb88c7309b3f48a4c279bd3afea29f65a766e9036", size = 18260101, upload-time = "2022-10-19T06:30:05.185Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/d9/f7a26d190a2062f2316ff046dcc64649a027b1959f02de5a8963fc7f7519/pandas-1.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:36aa1f8f680d7584e9b572c3203b20d22d697c31b71189322f16811d4ecfecd3", size = 11846057, upload-time = "2022-10-19T06:30:14.295Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/49/dd246e74156757fe3c26e4b97a4a19fe219cab9092d71366f2456f4841f9/pandas-1.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bcf1a82b770b8f8c1e495b19a20d8296f875a796c4fe6e91da5ef107f18c5ecb", size = 10701254, upload-time = "2022-10-19T06:30:31.908Z" },
-    { url = "https://files.pythonhosted.org/packages/65/8f/78fff6273dbcbb4c30f51125bc72b254b222e73bb68cc0038fc614d8e1b5/pandas-1.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c25e5c16ee5c0feb6cf9d982b869eec94a22ddfda9aa2fbed00842cbb697624", size = 11366246, upload-time = "2022-10-19T06:30:40.969Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/a6/14bd623f06a05b551cdb51cc2ec8cbe3af8a6928fe0b8b5ffc6b4c5423fa/pandas-1.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:932d2d7d3cab44cfa275601c982f30c2d874722ef6396bb539e41e4dc4618ed4", size = 12009827, upload-time = "2022-10-19T06:30:48.99Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bb/c3353704906030210d7d5bec81577715ba3a320ef0ece44cac3b29324b16/pandas-1.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:eb7e8cf2cf11a2580088009b43de84cabbf6f5dae94ceb489f28dba01a17cb77", size = 10294864, upload-time = "2022-10-19T06:30:56.343Z" },
-]
-
-[[package]]
-name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
@@ -1522,6 +1529,84 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
     { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
     { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/35/6411db530c618e0e0005187e35aa02ce60ae4c4c4d206964a2f978217c27/pandas-3.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a727a73cbdba2f7458dc82449e2315899d5140b449015d822f515749a46cbbe0", size = 10326926, upload-time = "2026-03-31T06:46:08.29Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/d3/b7da1d5d7dbdc5ef52ed7debd2b484313b832982266905315dad5a0bf0b1/pandas-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dbbd4aa20ca51e63b53bbde6a0fa4254b1aaabb74d2f542df7a7959feb1d760c", size = 9926987, upload-time = "2026-03-31T06:46:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/52/77/9b1c2d6070b5dbe239a7bc889e21bfa58720793fb902d1e070695d87c6d0/pandas-3.0.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:339dda302bd8369dedeae979cb750e484d549b563c3f54f3922cb8ff4978c5eb", size = 10757067, upload-time = "2026-03-31T06:46:14.903Z" },
+    { url = "https://files.pythonhosted.org/packages/20/17/ec40d981705654853726e7ac9aea9ddbb4a5d9cf54d8472222f4f3de06c2/pandas-3.0.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61c2fd96d72b983a9891b2598f286befd4ad262161a609c92dc1652544b46b76", size = 11258787, upload-time = "2026-03-31T06:46:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e3/3f1126d43d3702ca8773871a81c9f15122a1f412342cc56284ffda5b1f70/pandas-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c934008c733b8bbea273ea308b73b3156f0181e5b72960790b09c18a2794fe1e", size = 11771616, upload-time = "2026-03-31T06:46:20.532Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cf/0f4e268e1f5062e44a6bda9f925806721cd4c95c2b808a4c82ebe914f96b/pandas-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:60a80bb4feacbef5e1447a3f82c33209c8b7e07f28d805cfd1fb951e5cb443aa", size = 12337623, upload-time = "2026-03-31T06:46:23.754Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/97a6339859d4acb2536efb24feb6708e82f7d33b2ed7e036f2983fcced82/pandas-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:ed72cb3f45190874eb579c64fa92d9df74e98fd63e2be7f62bce5ace0ade61df", size = 9897372, upload-time = "2026-03-31T06:46:26.703Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/eb/781516b808a99ddf288143cec46b342b3016c3414d137da1fdc3290d8860/pandas-3.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:f12b1a9e332c01e09510586f8ca9b108fd631fd656af82e452d7315ef6df5f9f", size = 9154922, upload-time = "2026-03-31T06:46:30.284Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b0/c20bd4d6d3f736e6bd6b55794e9cd0a617b858eaad27c8f410ea05d953b7/pandas-3.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:232a70ebb568c0c4d2db4584f338c1577d81e3af63292208d615907b698a0f18", size = 10347921, upload-time = "2026-03-31T06:46:33.36Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d0/4831af68ce30cc2d03c697bea8450e3225a835ef497d0d70f31b8cdde965/pandas-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:970762605cff1ca0d3f71ed4f3a769ea8f85fc8e6348f6e110b8fea7e6eb5a14", size = 9888127, upload-time = "2026-03-31T06:46:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a9/16ea9346e1fc4a96e2896242d9bc674764fb9049b0044c0132502f7a771e/pandas-3.0.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aff4e6f4d722e0652707d7bcb190c445fe58428500c6d16005b02401764b1b3d", size = 10399577, upload-time = "2026-03-31T06:46:39.224Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a8/3a61a721472959ab0ce865ef05d10b0d6bfe27ce8801c99f33d4fa996e65/pandas-3.0.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef8b27695c3d3dc78403c9a7d5e59a62d5464a7e1123b4e0042763f7104dc74f", size = 10880030, upload-time = "2026-03-31T06:46:42.412Z" },
+    { url = "https://files.pythonhosted.org/packages/da/65/7225c0ea4d6ce9cb2160a7fb7f39804871049f016e74782e5dade4d14109/pandas-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f8d68083e49e16b84734eb1a4dcae4259a75c90fb6e2251ab9a00b61120c06ab", size = 11409468, upload-time = "2026-03-31T06:46:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/46e7c76032639f2132359b5cf4c785dd8cf9aea5ea64699eac752f02b9db/pandas-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:32cc41f310ebd4a296d93515fcac312216adfedb1894e879303987b8f1e2b97d", size = 11936381, upload-time = "2026-03-31T06:46:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/8b/721a9cff6fa6a91b162eb51019c6243b82b3226c71bb6c8ef4a9bd65cbc6/pandas-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:a4785e1d6547d8427c5208b748ae2efb64659a21bd82bf440d4262d02bfa02a4", size = 9744993, upload-time = "2026-03-31T06:46:51.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/18/7f0bd34ae27b28159aa80f2a6799f47fda34f7fb938a76e20c7b7fe3b200/pandas-3.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:08504503f7101300107ecdc8df73658e4347586db5cfdadabc1592e9d7e7a0fd", size = 9056118, upload-time = "2026-03-31T06:46:54.548Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
 ]
 
 [[package]]
@@ -2289,12 +2374,22 @@ name = "scipy"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and sys_platform == 'linux'",
     "python_full_version == '3.11.*' and sys_platform == 'linux'",
-    "python_full_version >= '3.13' and sys_platform != 'linux'",
-    "python_full_version == '3.12.*' and sys_platform != 'linux'",
-    "python_full_version == '3.11.*' and sys_platform != 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },


### PR DESCRIPTION
Scaffolding for agent-driven development, ported from flowbench-sw and adapted to goggles (library-scoped, no robotics/hardware specifics):

- .claude/CLAUDE.md: Claude Code entry point
- .agent/rules/rules.md + .agent/workflows/: slash-command wrappers
- docs/: central hub with index, standards (12 topics), workflows (orientation/feature/bugfix/refactor/api-validation/docs), agent personas, and an architecture map of goggles/ vs _core/

Tooling upgrades:

- pre-commit split into commit-stage (ruff, ruff-format, pydoclint, hygiene) and pre-push (basedpyright + pytest), so commits stay fast
- ruff: add D (pydocstyle google) and W505 (doc-line-too-long), with per-file ignores for tests/, examples/, and __init__.py; set max-doc-length=80

Drive-by fixes to satisfy the new rules:

- goggles/_core/integrations/wandb.py: import ordering (I001)
- goggles/filters.py: docstrings on RangeRejectFilter.reset and StdRejectFilter.reset (D102)