### PR TITLE
fix(filters): initialize ring-buffer index in __init__

### DIFF
--- a/goggles/filters.py
+++ b/goggles/filters.py
@@ -366,6 +366,7 @@ class _WindowBufferFilter(_BackendAware):
         super().__init__(prefix=prefix)
         self.window_size = window_size
         self.buffer: Array | None = None
+        self.index: int = 0
         self.n_seen: int = 0
 
     def _push(self, data: Array) -> tuple[ModuleType, int]:
@@ -385,7 +386,6 @@ class _WindowBufferFilter(_BackendAware):
             self.buffer = xp.zeros(
                 (self.window_size, *data.shape), dtype=data.dtype
             )
-            self.index: int = 0
 
         # buffer is guaranteed to be non-None here
         assert self.buffer is not None, "Buffer should be initialized"

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -208,6 +208,28 @@ def test_averagefilter_name() -> None:
 
 
 @pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: AverageFilter(window_size=3),
+        lambda: MedianFilter(window_size=3),
+        lambda: StdRejectFilter(
+            std_factor=2.0,
+            window_size=3,
+            fallback_filter=[
+                {"type": "AverageFilter", "parameters": {"window_size": 3}}
+            ],
+        ),
+    ],
+    ids=["AverageFilter", "MedianFilter", "StdRejectFilter"],
+)
+def test_windowbuffer_filter_init_state(factory: Any) -> None:
+    f = factory()
+    assert f.buffer is None
+    assert f.n_seen == 0
+    assert f.index == 0
+
+
+@pytest.mark.parametrize(
     "window_size",
     [0, -1, 2.5, -3.5],
 )


### PR DESCRIPTION
## Summary
- `_WindowBufferFilter` set `self.index = 0` only on the first `_push()`, so accessing `.index` on a freshly-constructed filter raised `AttributeError`.
- Move the init alongside `buffer` and `n_seen`, and cover `AverageFilter` / `MedianFilter` / `StdRejectFilter` with a parametrized init-state test.

Closes #118.

## Test plan
- [x] `uv run pytest tests/test_filter.py` — 229 passed
- [x] `uv run pre-commit run --all-files --hook-stage pre-push`

> Stacked on top of #143; merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
