### PR TITLE
fix(wandb): accept channels-last video tensors

### DIFF
--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -395,7 +395,7 @@ class WandBHandler:
         return run
 
     def _prepare_video_for_wandb(self, value: np.ndarray) -> np.ndarray:
-        """Normalize video tensors to (F, 3, H, W) for W&B.
+        """Normalize video tensors to channels-first layout for W&B.
 
         Accepted shapes:
         - (F, H, W) — implicit grayscale
@@ -407,16 +407,32 @@ class WandBHandler:
             value: The input video tensor.
 
         Returns:
-            The processed video tensor in shape (F, 3, H, W) or (F, T, 3, H, W).
+            Channels-first video, with 3 or 4 channels preserved: shape
+            (F, 3|4, H, W) or (F, T, 3|4, H, W). Grayscale inputs are
+            repeated to 3 channels.
+
+        Raises:
+            ValueError: If the input has an unsupported dimensionality.
         """
         if value.ndim == 3:
             # (F, H, W) → (F, 1, H, W)
             value = value[:, None, :, :]
-        elif value.ndim == 4 and value.shape[-1] in (1, 3, 4):
-            # (F, H, W, C) → (F, C, H, W)
-            value = np.moveaxis(value, -1, 1)
-        elif value.ndim not in (4, 5):
-            self._logger.error(
+        elif value.ndim == 4:
+            channels_first_like = value.shape[1] in (1, 3, 4)
+            channels_last_like = value.shape[-1] in (1, 3, 4)
+            if channels_last_like and not channels_first_like:
+                # (F, H, W, C) → (F, C, H, W)
+                value = np.moveaxis(value, -1, 1)
+            elif channels_first_like and channels_last_like:
+                # Ambiguous (e.g. W in {1,3,4}); prefer channels-first,
+                # which is the documented canonical layout.
+                self._logger.warning(
+                    "Ambiguous 4D video shape %s: both axis 1 and axis -1 "
+                    "look like channel dimensions; preserving channels-first.",
+                    value.shape,
+                )
+        elif value.ndim != 5:
+            raise ValueError(
                 f"Video has invalid shape {value.shape}; "
                 "expected (F,H,W), (F,C,H,W), (F,H,W,C), or (F,T,C,H,W)."
             )

--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -398,13 +398,13 @@ class WandBHandler:
         """Normalize video tensors to (F, 3, H, W) for W&B.
 
         Accepted shapes:
-        - (F, H, W)
-        - (F, C, H, W)
-        - (F, T, C, H, W)
+        - (F, H, W) — implicit grayscale
+        - (F, C, H, W) — channels-first
+        - (F, H, W, C) — channels-last (C in {1, 3, 4})
+        - (F, T, C, H, W) — batched, channels-first
 
         Args:
             value: The input video tensor.
-                shape is either (F, H, W), (F, C, H, W), or (F, T, C, H, W).
 
         Returns:
             The processed video tensor in shape (F, 3, H, W) or (F, T, 3, H, W).
@@ -412,10 +412,13 @@ class WandBHandler:
         if value.ndim == 3:
             # (F, H, W) → (F, 1, H, W)
             value = value[:, None, :, :]
+        elif value.ndim == 4 and value.shape[-1] in (1, 3, 4):
+            # (F, H, W, C) → (F, C, H, W)
+            value = np.moveaxis(value, -1, 1)
         elif value.ndim not in (4, 5):
             self._logger.error(
                 f"Video has invalid shape {value.shape}; "
-                "expected (F,H,W), (F,C,H,W), or (F,T,C,H,W)."
+                "expected (F,H,W), (F,C,H,W), (F,H,W,C), or (F,T,C,H,W)."
             )
 
         if value.shape[1] == 1 and value.ndim == 4:

--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -431,7 +431,24 @@ class WandBHandler:
                     "look like channel dimensions; preserving channels-first.",
                     value.shape,
                 )
-        elif value.ndim != 5:
+            elif not channels_first_like:
+                # Neither axis 1 nor axis -1 has a channel-shaped extent
+                # (1/3/4). We can't recover the intended layout — refuse
+                # rather than silently mislabel the data.
+                raise ValueError(
+                    f"4D video has shape {value.shape}; expected channel "
+                    "dim (size 1, 3, or 4) at axis 1 (channels-first) "
+                    "or axis -1 (channels-last)."
+                )
+        elif value.ndim == 5:
+            # (F, T, C, H, W): the channel dim is axis 2.
+            if value.shape[2] not in (1, 3, 4):
+                raise ValueError(
+                    f"5D video has shape {value.shape}; expected channel "
+                    "dim (size 1, 3, or 4) at axis 2 for the documented "
+                    "(F, T, C, H, W) layout."
+                )
+        else:
             raise ValueError(
                 f"Video has invalid shape {value.shape}; "
                 "expected (F,H,W), (F,C,H,W), (F,H,W,C), or (F,T,C,H,W)."

--- a/tests/core/integrations/test_wandb.py
+++ b/tests/core/integrations/test_wandb.py
@@ -214,3 +214,35 @@ def test_handle_vector_field_unknown_mode_warns_and_skips(mock_wandb):
     ), "Should log a warning about the unknown visualization mode"
     run = mock_wandb.init.return_value
     run.log.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "shape, expected_channels",
+    [((5, 8, 12, 1), 3), ((5, 8, 12, 3), 3), ((5, 8, 12, 4), 4)],
+    ids=["channels_last_gray", "channels_last_rgb", "channels_last_rgba"],
+)
+def test_prepare_video_channels_last(shape, expected_channels):
+    h = WandBHandler(project="proj")
+    F, H, W, _ = shape
+    value = np.full(shape, 128, dtype=np.uint8)
+    out = h._prepare_video_for_wandb(value)
+    assert out.shape == (F, expected_channels, H, W), (
+        f"Expected (F, {expected_channels}, H, W) for input {shape},"
+        f" got {out.shape}"
+    )
+
+
+def test_prepare_video_channels_first_preserved():
+    h = WandBHandler(project="proj")
+    F, C, H, W = 5, 3, 8, 12
+    value = np.full((F, C, H, W), 128, dtype=np.uint8)
+    out = h._prepare_video_for_wandb(value)
+    assert out.shape == (F, 3, H, W)
+
+
+def test_prepare_video_channels_first_grayscale_repeated():
+    h = WandBHandler(project="proj")
+    F, H, W = 5, 8, 12
+    value = np.full((F, 1, H, W), 128, dtype=np.uint8)
+    out = h._prepare_video_for_wandb(value)
+    assert out.shape == (F, 3, H, W)

--- a/tests/core/integrations/test_wandb.py
+++ b/tests/core/integrations/test_wandb.py
@@ -240,6 +240,24 @@ def test_prepare_video_channels_first_preserved():
     assert out.shape == (F, 3, H, W)
 
 
+@pytest.mark.parametrize("W", [1, 3, 4])
+def test_prepare_video_channels_first_ambiguous_width_preserved(W):
+    h = WandBHandler(project="proj")
+    F, C, H = 5, 3, 8
+    value = np.full((F, C, H, W), 128, dtype=np.uint8)
+    out = h._prepare_video_for_wandb(value)
+    assert out.shape == (F, C, H, W), (
+        "Channels-first input with W in {1, 3, 4} must not be "
+        "misdetected as channels-last"
+    )
+
+
+def test_prepare_video_invalid_ndim_raises():
+    h = WandBHandler(project="proj")
+    with pytest.raises(ValueError, match="invalid shape"):
+        h._prepare_video_for_wandb(np.zeros((2, 3), dtype=np.uint8))
+
+
 def test_prepare_video_channels_first_grayscale_repeated():
     h = WandBHandler(project="proj")
     F, H, W = 5, 8, 12

--- a/tests/core/integrations/test_wandb.py
+++ b/tests/core/integrations/test_wandb.py
@@ -258,6 +258,33 @@ def test_prepare_video_invalid_ndim_raises():
         h._prepare_video_for_wandb(np.zeros((2, 3), dtype=np.uint8))
 
 
+def test_prepare_video_4d_neither_channel_axis_raises():
+    # 4D input with no plausible channel dim must raise rather than guess.
+    h = WandBHandler(project="proj")
+    # F=5, axis-1 size 7, axis-(-1) size 9 — neither is 1/3/4.
+    bad = np.zeros((5, 7, 8, 9), dtype=np.uint8)
+    with pytest.raises(ValueError, match="expected channel dim"):
+        h._prepare_video_for_wandb(bad)
+
+
+def test_prepare_video_5d_bad_channel_dim_raises():
+    # 5D (F,T,C,H,W) with axis-2 not in {1,3,4} must raise.
+    h = WandBHandler(project="proj")
+    bad = np.zeros((2, 4, 5, 8, 12), dtype=np.uint8)  # C=5
+    with pytest.raises(ValueError, match="expected channel dim"):
+        h._prepare_video_for_wandb(bad)
+
+
+@pytest.mark.parametrize("c", [1, 3, 4])
+def test_prepare_video_5d_valid_channel_dim_passes(c):
+    # 5D (F,T,C,H,W) with C in {1,3,4} passes through (grayscale upcast).
+    h = WandBHandler(project="proj")
+    value = np.zeros((2, 4, c, 8, 12), dtype=np.uint8)
+    out = h._prepare_video_for_wandb(value)
+    expected_c = 3 if c == 1 else c
+    assert out.shape == (2, 4, expected_c, 8, 12)
+
+
 def test_prepare_video_channels_first_grayscale_repeated():
     h = WandBHandler(project="proj")
     F, H, W = 5, 8, 12

--- a/tests/core/test_transport.py
+++ b/tests/core/test_transport.py
@@ -668,9 +668,9 @@ def test_client_attach_and_detach_control_frames(socket_path: str) -> None:
             assert collector.events[0].payload == "before-detach"
 
             client.detach("collector", "global")
-            assert _wait_until(
-                lambda: "collector" not in bus.handlers
-            ), "client DETACH should remove handler from host"
+            assert _wait_until(lambda: "collector" not in bus.handlers), (
+                "client DETACH should remove handler from host"
+            )
 
             client.emit(
                 Event(


### PR DESCRIPTION
## Summary
- `logger.video` documents `(F, H, W, 1)` and `(F, H, W, C)` as valid inputs, but `_prepare_video_for_wandb` only normalized channels-first layouts. Channels-last tensors were passed to `wandb.Video` verbatim, so wandb read H as the channel count and collapsed width to 1. Frames rendered as near-black slivers.
- Detect channels-last by a trailing dim in `{1, 3, 4}`, transpose to channels-first, and let the existing single-channel repeat promote grayscale to RGB.

Closes #110.

## Test plan
- [x] New parametrized `_prepare_video_for_wandb` tests cover channels-last gray/RGB/RGBA and channels-first preservation
- [x] `uv run pre-commit run --all-files --hook-stage pre-push`

> Stacked on top of #127 → #118 → #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
