### PR TITLE
fix(wandb): do not mutate shared event.extra

### DIFF
--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -129,7 +129,9 @@ class WandBHandler:
         kind = getattr(event, "kind", None) or "metric"
         step = getattr(event, "step", None)
         payload = getattr(event, "payload", None)
-        extra = getattr(event, "extra", {}) or {}
+        # Copy so our .pop(...) calls don't mutate the shared event.extra
+        # that other handlers on the same bus will read afterwards.
+        extra = dict(getattr(event, "extra", {}) or {})
         extra_config = extra.pop("config_wandb", {})
 
         # Get or create the W&B run for the given scope

--- a/tests/core/integrations/test_wandb.py
+++ b/tests/core/integrations/test_wandb.py
@@ -285,6 +285,39 @@ def test_prepare_video_5d_valid_channel_dim_passes(c):
     assert out.shape == (2, 4, expected_c, 8, 12)
 
 
+@pytest.mark.parametrize(
+    "kind, payload",
+    [
+        ("image", np.zeros((4, 4, 3), dtype=np.uint8)),
+        ("video", np.zeros((2, 4, 4, 3), dtype=np.uint8)),
+        ("histogram", np.zeros(32, dtype=np.float32)),
+    ],
+    ids=["image", "video", "histogram"],
+)
+def test_handle_does_not_mutate_event_extra(mock_wandb, kind, payload):
+    h = WandBHandler(project="proj")
+    extra = {
+        "name": "thing",
+        "format": "png",
+        "fps": 10,
+        "config_wandb": {"x": 1},
+        "tag": "viz",
+    }
+    snapshot = dict(extra)
+    event = SimpleNamespace(
+        kind=kind,
+        scope="global",
+        payload=payload,
+        step=0,
+        extra=extra,
+    )
+    h.handle(event)
+    assert extra == snapshot, (
+        f"Handler mutated event.extra for kind={kind!r}: "
+        f"before={snapshot}, after={extra}"
+    )
+
+
 def test_prepare_video_channels_first_grayscale_repeated():
     h = WandBHandler(project="proj")
     F, H, W = 5, 8, 12


### PR DESCRIPTION
## Summary
- `WandBHandler.handle` was calling `.pop` on `event.extra` (for `config_wandb`, `name`, `fps`, `mode`, `static`, `num_bins`, …). `event.extra` is shared across handlers on the bus, so running alongside `LocalStorageHandler` with WandB first stripped `name` before storage read it — media files landed under a random UUID.
- Handler iteration order is non-deterministic (set-backed scopes), which explains why the bug was intermittent.
- Defensively copy `extra` once on entry and operate on the copy. Add parametrized regression tests covering image / video / histogram payloads.

Closes #73.

## Test plan
- [x] Regression tests fail on the prior code (verified by stash-pop) and pass on the fix
- [x] `uv run pre-commit run --all-files --hook-stage pre-push`

> Stacked on top of #110 → #127 → #118 → #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
