### PR TITLE
fix(config)!: reject private-field overrides in from_config

### DIFF
--- a/goggles/config.py
+++ b/goggles/config.py
@@ -82,13 +82,19 @@ class PrettyConfig(dict):
         """Create an instance from a config dict.
 
         For dataclass subclasses:
-            - Only dataclass fields are accepted.
+            - Only declared public fields (no leading ``_``) may be set.
             - Missing values fall back to the dataclass defaults.
-            - Extra keys are ignored.
-            - Keys starting with '_' are ignored.
+            - Unknown keys (typos, extras) are silently ignored so
+              that callers can hand the same dict through multiple
+              ``from_config`` consumers without pre-filtering.
+            - Keys matching a declared private (``_``-prefixed) field
+              raise ``ValueError``: declared private state is not
+              configurable from a config dict by design, and silently
+              dropping a key that points at a real attribute would
+              hide a bug.
 
         For non-dataclass usage:
-            - Behaves like `cls(config)`.
+            - Behaves like ``cls(config)``.
 
         Args:
             config: Source configuration mapping.
@@ -96,17 +102,26 @@ class PrettyConfig(dict):
         Returns:
             A configuration instance of `cls`.
 
+        Raises:
+            ValueError: If ``config`` contains keys that name declared
+                private (``_``-prefixed) fields on the dataclass.
         """
         if not is_dataclass(cls):
             return cls(config)
 
-        # Keep only known dataclass fields.
-        allowed = {f.name for f in fields(cls) if not f.name.startswith("_")}
-
-        filtered = {k: v for k, v in config.items() if k in allowed}
-
-        # Instantiating the dataclass will apply defaults automatically.
-        return cls(**filtered)  # type: ignore[misc]
+        declared = {f.name for f in fields(cls)}
+        private_hits = sorted(
+            k for k in config if k in declared and k.startswith("_")
+        )
+        if private_hits:
+            raise ValueError(
+                f"Private fields cannot be overridden via from_config: "
+                f"{private_hits}."
+            )
+        # Unknown keys are silently dropped — callers can hand the
+        # same dict to several consumers without pre-filtering.
+        known = {k: v for k, v in config.items() if k in declared}
+        return cls(**known)  # type: ignore[misc]
 
     def to_yaml(self, file_path: str) -> None:
         """Save configuration to a YAML file.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,8 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
+import pytest
+
 from goggles.config import PrettyConfig, load_configuration
 
 
@@ -142,24 +144,29 @@ def test_yaml_and_json_roundtrip_via_prettyconfig_loaders(
     )
 
 
-def test_private_fields_are_not_overwritten_by_from_config() -> None:
-    """Keys starting with '_' must be ignored by from_config."""
-    cfg = DummyTypedConfig.from_config(
-        {
-            "_secret": "hacked",
-            "name": "x",
-            "port": "y",
-        }
-    )
+def test_private_fields_cannot_be_overridden_by_from_config() -> None:
+    """A declared `_`-prefixed field must not be settable from config."""
+    with pytest.raises(ValueError) as exc_info:
+        DummyTypedConfig.from_config(
+            {
+                "_secret": "hacked",
+                "name": "x",
+                "port": "y",
+            }
+        )
+    msg = str(exc_info.value)
+    assert "Private fields cannot be overridden" in msg
+    assert "_secret" in msg
 
-    assert cfg.name == "x", "Public field must be set from config."
-    assert cfg.port == "y", "Public field must be set from config."
-    assert cfg._secret == "dont-serialize", (
-        "Private field must keep default value."
+
+def test_undeclared_private_keys_are_silently_ignored() -> None:
+    """Undeclared `_`-prefixed keys are unknown keys, not private hits."""
+    cfg = DummyTypedConfig.from_config(
+        {"_not_declared": 1, "name": "x", "port": "y"}
     )
-    assert "_secret" not in cfg, (
-        "Private field must not appear in dict payload."
-    )
+    assert cfg.name == "x"
+    assert cfg.port == "y"
+    assert not hasattr(cfg, "_not_declared")
 
 
 def test_private_fields_not_serialized_yaml_json_roundtrip(


### PR DESCRIPTION
## Summary
`PrettyConfig.from_config` previously dropped attempts to override
`_`-prefixed declared fields silently. That let a config file mention
a real private attribute by name (e.g. `_secret: ...`) and behave as
if the key wasn't there, leaving the default in place — disguising
config bugs as no-ops.

Make those overrides explicit:
- **Declared private fields** (`_`-prefixed names that exist on the
  dataclass) → `ValueError("Private fields cannot be overridden via from_config: {...}.")`

**Unknown keys** (typos, extras) keep their existing silent-ignore
behavior so the same dict can be passed through multiple
`from_config` consumers without pre-filtering. Undeclared
`_`-prefixed keys are treated as unknown (also silently ignored),
not as private-field hits.

**Breaking change** — callers that relied on silent-drop of
declared-private overrides now see `ValueError`.

Closes #141.

## Test plan
- [x] New test: declared `_secret` override raises with the expected message.
- [x] New test: undeclared `_not_declared` key is silently ignored (not classified as private).
- [x] Existing `test_from_config_ignores_unknown_keys` still passes (unknown keys behavior unchanged).
- [x] `uv run pytest tests/test_config.py` (7 passed).
- [x] `uv run pre-commit run --all-files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
