### PR TITLE
feat(logger): promote image-shaped values passed to push()

### DIFF
--- a/examples/107_push_images.py
+++ b/examples/107_push_images.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import numpy as np
+
+import goggles as gg
+
+# `logger.push({...})` used to batch every value as a metric. With image
+# promotion, image-shaped numpy arrays in the mapping are split out into
+# individual image events while scalars stay in a single metric event.
+# Image-shaped means: a 2-D array, OR a 3-D array with a trailing
+# channel axis in {1, 3, 4}.
+
+LOG_DIR = Path("examples/logs/107_push")
+logger = gg.get_logger("examples.push", with_metrics=True)
+gg.attach(
+    gg.LocalStorageHandler(path=LOG_DIR, name="examples.push"),
+)
+gg.attach(
+    gg.ConsoleHandler(name="examples.push.console", level=gg.INFO),
+)
+
+print(f"=== writing logs to {LOG_DIR} ===\n")
+
+rng = np.random.default_rng(0)
+gray = rng.integers(0, 255, (64, 64), dtype=np.uint8)  # (H, W) -> image
+rgb = rng.integers(0, 255, (64, 64, 3), dtype=np.uint8)  # (H, W, 3) -> image
+rgba = rng.integers(0, 255, (64, 64, 4), dtype=np.uint8)  # (H, W, 4) -> image
+
+# Mixed batch: 2 scalars + 3 image-shaped arrays. The two scalars go
+# out as a single metric event; each image becomes its own image event
+# with the dict key as its name.
+logger.push(
+    {
+        "loss": 0.123,
+        "accuracy": 0.91,
+        "samples/gray": gray,
+        "samples/rgb": rgb,
+        "samples/rgba": rgba,
+    },
+    step=0,
+)
+
+# Vector-shaped arrays (1-D, scalar) stay on the metric path. Mix
+# them with images in a single push without thinking about routing.
+logger.push(
+    {
+        "logits": np.array([0.1, 0.6, 0.3]),
+        "samples/rgb_2": rgb,
+    },
+    step=1,
+)
+
+# When the mapping is all images, no empty metric event is emitted.
+# Inspect log.jsonl after the run -- step=2 only has image entries.
+logger.push(
+    {"samples/rgb_3": rgb, "samples/gray_2": gray},
+    step=2,
+)
+
+gg.finish()
+
+print()
+print("Inspect:")
+print(f"- {LOG_DIR}/log.jsonl  -- one event per line")
+print(f"- {LOG_DIR}/images/    -- individual PNGs per promoted key")

--- a/goggles/_core/logger.py
+++ b/goggles/_core/logger.py
@@ -11,7 +11,7 @@ External code should not import from this module. Instead, depend on:
 import inspect
 import logging
 import os
-from typing import Any
+from typing import Any, TypeGuard
 
 import numpy as np
 from typing_extensions import Self
@@ -376,31 +376,69 @@ class CoreGogglesLogger(GogglesLogger, CoreTextLogger):
         async_mode: bool = GOGGLES_ASYNC,
         **extra: Any,
     ) -> None:
-        """Emit a batch of scalar metrics.
+        """Emit a batch of metrics and/or images in one call.
+
+        Values that look like images (2-D arrays, or 3-D arrays with a
+        trailing channel dim in ``{1, 3, 4}``) are promoted to individual
+        image events; every other value is batched into a single metric
+        event. Scalars and images can be mixed freely in the same call.
 
         Args:
-            metrics: (Name,value) pairs.
+            metrics: Mapping of ``name -> value``. Values may be scalars,
+                arrays used as metrics, or image-shaped numpy arrays.
             step: Global step index.
             time: Optional global timestamp.
             async_mode: If True, do not block waiting for delivery.
-            **extra: Additional routing metadata (e.g., split="train").
-
+            **extra: Additional routing metadata (e.g. ``split="train"``)
+                forwarded both to the batched metric event and to each
+                promoted image event.
         """
         filepath, lineno = _caller_id()
-        self._dispatch(
-            Event(
-                kind="metric",
-                scope=self._scope,
-                payload=metrics,
-                level=None,
-                filepath=filepath,
-                lineno=lineno,
-                step=step,
-                time=time,
-                extra={**self._bound, **extra},
-            ),
-            async_mode=async_mode,
-        )
+        bound_extra = {**self._bound, **extra}
+
+        scalars: dict[str, Any] = {}
+        images: dict[str, np.ndarray] = {}
+        for name, value in metrics.items():
+            if _is_push_image(value):
+                images[name] = value
+            else:
+                scalars[name] = value
+
+        if scalars:
+            self._dispatch(
+                Event(
+                    kind="metric",
+                    scope=self._scope,
+                    payload=scalars,
+                    level=None,
+                    filepath=filepath,
+                    lineno=lineno,
+                    step=step,
+                    time=time,
+                    extra=bound_extra,
+                ),
+                async_mode=async_mode,
+            )
+
+        for img_name, img in images.items():
+            self._dispatch(
+                Event(
+                    kind="image",
+                    scope=self._scope,
+                    payload=img,
+                    level=None,
+                    filepath=filepath,
+                    lineno=lineno,
+                    step=step,
+                    time=time,
+                    extra={
+                        **bound_extra,
+                        "name": img_name,
+                        "format": "png",
+                    },
+                ),
+                async_mode=async_mode,
+            )
 
     def scalar(
         self,
@@ -807,6 +845,26 @@ class CoreGogglesLogger(GogglesLogger, CoreTextLogger):
                 self.vector_field(value, name=name_log, **kw)
                 return True
         return False
+
+
+def _is_push_image(value: Any) -> TypeGuard[np.ndarray]:
+    """Return whether ``value`` should be promoted from metric to image.
+
+    Args:
+        value: Candidate payload from a :meth:`CoreGogglesLogger.push`
+            mapping.
+
+    Returns:
+        ``True`` when the value is a 2-D numpy array, or a 3-D numpy
+        array whose trailing axis is ``1``, ``3``, or ``4`` channels.
+        Anything else (scalars, 1-D vectors, higher-rank tensors, other
+        channel counts) stays on the metric path.
+    """
+    if not isinstance(value, np.ndarray):
+        return False
+    if value.ndim == 2:
+        return True
+    return value.ndim == 3 and value.shape[-1] in (1, 3, 4)
 
 
 def _caller_id() -> tuple[str, int]:

--- a/goggles/_core/logger.py
+++ b/goggles/_core/logger.py
@@ -391,7 +391,10 @@ class CoreGogglesLogger(GogglesLogger, CoreTextLogger):
             async_mode: If True, do not block waiting for delivery.
             **extra: Additional routing metadata (e.g. ``split="train"``)
                 forwarded both to the batched metric event and to each
-                promoted image event.
+                promoted image event. For promoted image events, ``name`` is
+                always overridden with the metric key, and ``format``
+                defaults to ``"png"`` if not provided in ``extra`` or the
+                bound context.
         """
         filepath, lineno = _caller_id()
         bound_extra = {**self._bound, **extra}
@@ -432,9 +435,9 @@ class CoreGogglesLogger(GogglesLogger, CoreTextLogger):
                     step=step,
                     time=time,
                     extra={
+                        "format": "png",
                         **bound_extra,
                         "name": img_name,
-                        "format": "png",
                     },
                 ),
                 async_mode=async_mode,

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -178,6 +178,7 @@ def test_push_promotes_image_shaped_ndarrays(
     event = patch_bus.emit.call_args_list[0].args[0]
     np.testing.assert_array_equal(event.payload, img)
     assert event.extra["name"] == "fig"
+    assert event.extra["format"] == "png"
     assert event.step == 3
 
 

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -2,6 +2,7 @@ import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 
 from goggles._core.logger import CoreGogglesLogger, CoreTextLogger
@@ -151,6 +152,109 @@ def test_push_emits_metric_event(
     assert event.kind == "metric", "Event kind should be 'metric'"
     assert event.payload == metrics, "Event payload should match pushed metrics"
     assert event.step == 2, "Event step mismatch"
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [(8, 12), (8, 12, 1), (8, 12, 3), (8, 12, 4)],
+    ids=["hw", "hw1", "hw3", "hw4"],
+)
+def test_push_promotes_image_shaped_ndarrays(
+    goggles_logger: CoreGogglesLogger,
+    patch_bus: MagicMock,
+    shape: tuple[int, ...],
+) -> None:
+    """Image-shaped ndarrays passed to ``push`` are emitted as image events.
+
+    Args:
+        goggles_logger: ``CoreGogglesLogger`` fixture.
+        patch_bus: Patched mock client fixture.
+        shape: Tensor shape under test (parametrized).
+    """
+    img = np.zeros(shape, dtype=np.uint8)
+    goggles_logger.push({"fig": img}, step=3)
+    kinds = [c.args[0].kind for c in patch_bus.emit.call_args_list]
+    assert kinds == ["image"]
+    event = patch_bus.emit.call_args_list[0].args[0]
+    np.testing.assert_array_equal(event.payload, img)
+    assert event.extra["name"] == "fig"
+    assert event.step == 3
+
+
+def test_push_keeps_1d_ndarray_as_metric(
+    goggles_logger: CoreGogglesLogger, patch_bus: MagicMock
+) -> None:
+    """1-D ndarrays stay in the metric payload (not promoted to image).
+
+    Args:
+        goggles_logger: ``CoreGogglesLogger`` fixture.
+        patch_bus: Patched mock client fixture.
+    """
+    vec = np.arange(4, dtype=np.float32)
+    goggles_logger.push({"v": vec}, step=1)
+    event = patch_bus.emit.call_args[0][0]
+    assert event.kind == "metric"
+    np.testing.assert_array_equal(event.payload["v"], vec)
+
+
+def test_push_mixes_scalars_and_images(
+    goggles_logger: CoreGogglesLogger, patch_bus: MagicMock
+) -> None:
+    """``push`` splits a mixed dict into one metric event + per-image events.
+
+    Args:
+        goggles_logger: ``CoreGogglesLogger`` fixture.
+        patch_bus: Patched mock client fixture.
+    """
+    img1 = np.zeros((4, 4), dtype=np.uint8)
+    img2 = np.zeros((4, 4, 3), dtype=np.uint8)
+    goggles_logger.push(
+        {"loss": 0.1, "acc": 0.9, "fig1": img1, "fig2": img2}, step=5
+    )
+    events = [c.args[0] for c in patch_bus.emit.call_args_list]
+    kinds = [e.kind for e in events]
+    assert kinds.count("metric") == 1
+    assert kinds.count("image") == 2
+
+    metric_event = next(e for e in events if e.kind == "metric")
+    assert metric_event.payload == {"loss": 0.1, "acc": 0.9}
+    assert metric_event.step == 5
+
+    image_names = [e.extra["name"] for e in events if e.kind == "image"]
+    assert sorted(image_names) == ["fig1", "fig2"]
+    for e in events:
+        assert e.step == 5
+
+
+def test_push_image_only_does_not_emit_empty_metric_event(
+    goggles_logger: CoreGogglesLogger, patch_bus: MagicMock
+) -> None:
+    """Image-only ``push`` must not emit an empty metric event alongside.
+
+    Args:
+        goggles_logger: ``CoreGogglesLogger`` fixture.
+        patch_bus: Patched mock client fixture.
+    """
+    img = np.zeros((4, 4), dtype=np.uint8)
+    goggles_logger.push({"fig": img}, step=2)
+    kinds = [c.args[0].kind for c in patch_bus.emit.call_args_list]
+    assert "metric" not in kinds
+
+
+def test_push_forwards_extras_to_image_events(
+    goggles_logger: CoreGogglesLogger, patch_bus: MagicMock
+) -> None:
+    """Extras forwarded to ``push`` reach each promoted image event's extras.
+
+    Args:
+        goggles_logger: ``CoreGogglesLogger`` fixture.
+        patch_bus: Patched mock client fixture.
+    """
+    img = np.zeros((4, 4), dtype=np.uint8)
+    goggles_logger.push({"fig": img}, step=2, split="train")
+    event = patch_bus.emit.call_args[0][0]
+    assert event.kind == "image"
+    assert event.extra["split"] == "train"
 
 
 def test_scalar_emits_metric_event(


### PR DESCRIPTION
## Summary
`CoreGogglesLogger.push` now routes each value in the input mapping to the right event kind instead of batching everything as a metric:

- Entries whose value is a 2-D numpy array, or a 3-D numpy array with a trailing channel axis in `{1, 3, 4}`, are emitted as individual `image` events (one per key; `format="png"` by default, matching `logger.image(...)`).
- Everything else stays on the metric path and is emitted in a single batched `metric` event.
- Mixed inputs get both: exactly one metric event for the scalars plus one image event per image.
- Image-only inputs do not emit an empty metric event.

Collapses the motivating example from the issue:

```python
# before
logger.image(fig1, "fig1", step=s)
logger.image(fig2, "fig2", step=s)
logger.image(fig3, "fig3", step=s)
logger.image(fig4, "fig4", step=s)

# after
logger.push({"fig1": fig1, "fig2": fig2, "fig3": fig3, "fig4": fig4}, step=s)
```

and lets users mix scalars and figures freely:

```python
logger.push({"loss": 0.1, "acc": 0.9, "fig": arr}, step=s)
```

Closes #58.

## Implementation notes
- `_is_push_image(value)` is a `TypeGuard[np.ndarray]` so the static type of `images[name] = value` narrows after the check (keeps basedpyright happy without casts).
- Dispatch is inline in `push`: capture filepath/lineno once at entry, then construct the metric and image events directly. Going through `self.image(...)` would walk the stack again and tag every image event with `push()`'s own location instead of the user's.
- Shapes that stay on the metric path (1-D arrays, higher-rank tensors, non-`ndarray` values) are unchanged — this is purely additive.

Also shuffles the `import wandb` ordering in `goggles/_core/integrations/wandb.py` to match the ruff import-group policy (one isort violation that was flagging in pre-push).

## Test plan
- [x] New tests in `tests/core/test_logger.py` cover 2-D / 3-D×{1,3,4}-channel promotion, scalar+image mix, image-only (no empty metric event), 1-D arrays staying as metrics, and extras forwarded to image events.
- [x] `uv run pre-commit run --all-files --hook-stage pre-push` — ruff, ruff-format, pydoclint, basedpyright, pytest all green.

> Stacked on top of #155 → #154 → #153 → #152 → #151 → #150 → #149 → #148 → #147 → #146 → #145 → #144 → #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
