### PR TITLE
docs(examples): catch examples up with v0.2 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ uv run examples/04_wandb.py
 uv run examples/05_wandb_multiple_runs.py
 
 # Advanced: Custom handler
-uv run exacmples/06_custom_handler.py
+uv run examples/06_custom_handler.py
 
 # Graceful shutdown utils
 uv run examples/100_interrupt.py
 
-# Pretty and convenient utils for configuration laoding
+# Pretty and convenient utils for configuration loading
 uv run examples/101_config.py
 
 # Advanced: Performance decorators
@@ -195,6 +195,12 @@ uv run examples/102_decorators.py
 
 # Advanced: JAX device-resident histories
 uv run examples/103_history.py
+
+# Filters: smoothing, outlier rejection, composition
+uv run examples/104_filters.py
+
+# Benchmark: producer-side logging latency under Hydra presets
+uv run examples/105_benchmark.py
 ```
 
 ## 🧠 For Goggles power user

--- a/examples/01_basic_run.py
+++ b/examples/01_basic_run.py
@@ -33,4 +33,12 @@ logger.debug("This is a synchronous debug message.", async_mode=False)
 # if both are eligible.
 logger.info("This message will be logged by both handlers.")
 
+# Per-logger severity gate — useful to turn DEBUG on in a single module
+# without flooding the rest of the app. Also available at construction:
+# `gg.get_logger(__name__, level=gg.DEBUG)`.
+noisy = gg.get_logger("examples.basic.noisy")
+noisy.set_level(gg.WARNING)
+noisy.debug("dropped — below the gate")
+noisy.warning("shown — at/above the gate")
+
 gg.finish()

--- a/examples/01_basic_run.py
+++ b/examples/01_basic_run.py
@@ -33,9 +33,10 @@ logger.debug("This is a synchronous debug message.", async_mode=False)
 # if both are eligible.
 logger.info("This message will be logged by both handlers.")
 
-# Per-logger severity gate — useful to turn DEBUG on in a single module
-# without flooding the rest of the app. Also available at construction:
-# `gg.get_logger(__name__, level=gg.DEBUG)`.
+# Per-logger severity gate — useful to silence a noisy module without
+# touching the rest of the app's log level. Below, `noisy` drops DEBUG
+# locally while every other logger keeps emitting at its own level.
+# Also settable at construction: `gg.get_logger(__name__, level=gg.WARNING)`.
 noisy = gg.get_logger("examples.basic.noisy")
 noisy.set_level(gg.WARNING)
 noisy.debug("dropped — below the gate")

--- a/examples/03_local_storage.py
+++ b/examples/03_local_storage.py
@@ -52,6 +52,21 @@ logger.push(
     step=2,
 )
 
+# `push` also accepts image-shaped arrays (2-D, or 3-D with trailing
+# channel axis in {1, 3, 4}) and promotes them to individual image
+# events, so scalars + figures can land in a single call.
+logger.push(
+    {
+        "train/loss": 0.120,
+        "val/loss": 0.190,
+        "eval/confusion": np.random.randint(
+            0, 255, (32, 32, 3), dtype=np.uint8
+        ),
+        "eval/attention": np.random.randint(0, 255, (32, 32), dtype=np.uint8),
+    },
+    step=2,
+)
+
 # Image logging
 logger.info("Logging sample image...")
 dummy_image = np.random.randint(0, 255, (64, 64, 3), dtype=np.uint8)
@@ -194,6 +209,31 @@ logger.vector_field(
     step=8,
 )
 
+# Trajectories logging
+# `logger.trajectories` accepts arrays shaped (N, L, dim) with dim in {2, 3};
+# set `store_visualization=True` to also save a PNG preview alongside the .npy.
+logger.info("Logging sample trajectories (2D + 3D)...")
+rng = np.random.default_rng(0)
+N, L = 6, 40
+
+# 2-D random walk per trajectory
+trajectories_2d = np.cumsum(rng.normal(size=(N, L, 2), scale=0.1), axis=1)
+logger.trajectories(
+    trajectories_2d,
+    name="random_walk_2d",
+    store_visualization=True,
+    step=9,
+)
+
+# 3-D random walk per trajectory (matplotlib picks a 3D projection)
+trajectories_3d = np.cumsum(rng.normal(size=(N, L, 3), scale=0.1), axis=1)
+logger.trajectories(
+    trajectories_3d,
+    name="random_walk_3d",
+    store_visualization=True,
+    step=9,
+)
+
 # Histogram logging
 logger.info("Logging sample histogram...")
 histogram_data = np.random.randn(1000)
@@ -208,6 +248,7 @@ print("- examples/logs/images/ (contains saved image files)")
 print("- examples/logs/videos/ (contains saved video files)")
 print("- examples/logs/artifacts/ (contains saved artifact files)")
 print("- examples/logs/vector_fields/ (contains saved vector field files)")
+print("- examples/logs/trajectories/ (contains saved trajectory files)")
 print("- examples/logs/histograms/ (contains saved histogram files)")
 print("- Media files are referenced by relative paths in the JSONL log")
 

--- a/examples/03_local_storage.py
+++ b/examples/03_local_storage.py
@@ -210,8 +210,9 @@ logger.vector_field(
 )
 
 # Trajectories logging
-# `logger.trajectories` accepts arrays shaped (N, L, dim) with dim in {2, 3};
-# set `store_visualization=True` to also save a PNG preview alongside the .npy.
+# `logger.trajectories` accepts arrays shaped (N, L, dim) with dim in
+# {2, 3}. Set `store_visualization=True` to also save a PNG preview
+# alongside the .npy.
 logger.info("Logging sample trajectories (2D + 3D)...")
 rng = np.random.default_rng(0)
 N, L = 6, 40


### PR DESCRIPTION
## Summary
Scoped pass to close the gap between v0.2's landed features and what the `examples/` folder actually demonstrates. No new docs files — lean on the examples that already exist.

- `examples/01_basic_run.py` — add a `logger.set_level` snippet showing per-logger severity gating (#56), distinct from the handler-level filter already in the example.
- `examples/03_local_storage.py` —
  - Extend the `logger.push` section to demonstrate the image-promotion behavior from #58, mixing scalars and image-shaped arrays in one call (both 2-D grayscale and 3-D RGB; slash-prefixed names).
  - Add a `logger.trajectories` section between `vector_field` and `histogram`, covering both 2-D and 3-D with `store_visualization=True`.
  - Update the final directory-structure printout with `trajectories/`.
- `README.md` — fix `exacmples` / `laoding` typos; list the examples that landed during v0.2 but weren't in the README (`104_filters.py`, `105_benchmark.py`).

Closes #68.

## Test plan
- [x] `python examples/03_local_storage.py` runs clean and produces `trajectories/random_walk_2d_9.npy` + `trajectories/random_walk_3d_9.npy` plus matching PNG previews; the log.jsonl has 2 trajectories events and 5 image events (including the two pushed via `logger.push`).
- [x] `uv run pre-commit run --all-files --hook-stage pre-push` — ruff, ruff-format, pydoclint, basedpyright, pytest all green.

> Stacked on top of #156 → #155 → #154 → #153 → #152 → #151 → #150 → #149 → #148 → #147 → #146 → #145 → #144 → #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
