### PR TITLE
docs(retrospectives): add folder + shutdown BYE flush write-up

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,16 @@ Step-by-step procedures for common tasks:
 
 ---
 
+## Retrospectives
+
+Postmortem write-ups for non-obvious bugs. Linked from the regression
+test that guards each one.
+
+See [retrospectives/README.md](retrospectives/README.md) for the
+index.
+
+---
+
 ## Quick reference
 
 ```bash

--- a/docs/retrospectives/2026-04-shutdown-bye-flush.md
+++ b/docs/retrospectives/2026-04-shutdown-bye-flush.md
@@ -1,0 +1,48 @@
+# Shutdown drained `BYE` before its own send queue (April 2026)
+
+## What went wrong
+
+A run that emitted ~1500 video-log events before calling
+`gg.finish()` consistently delivered only **77 of them** to the host.
+The losses were silent — no exceptions, no warnings — and were only
+caught by manually counting frames on the receiver.
+
+## Root cause
+
+`LocalTransport` shutdown sent the `BYE` control frame **out-of-band**
+relative to the regular send queue:
+
+1. The producer thread was still appending event frames to
+   `_send_queue`.
+2. `_shutdown_client()` acquired `_send_lock` and `sendall()`'d a
+   `BYE` directly.
+3. The send loop, observing the `BYE` had been delivered, returned.
+4. Anything still sitting in `_send_queue` (typically the tail of the
+   producer's batch) was discarded when the loop tore down.
+
+The contract everyone *thought* was being honoured was "shutdown
+flushes the queue, then sends BYE". The implementation was "shutdown
+sends BYE, then tears down the queue". Under any non-trivial producer
+load the latter loses tail events.
+
+## Fix
+
+`_shutdown_client` now enqueues the `BYE` frame as the **last**
+element of `_send_queue` and waits for the send loop to drain naturally
+before joining the thread. PR
+[#143](https://github.com/antonioterpin/goggles/pull/143) lands this
+along with the broader Unix-socket transport rewrite.
+
+The regression is guarded by
+[`tests/core/test_transport.py::test_shutdown_flushes_pending_events`](../../tests/core/test_transport.py),
+which emits 500 events back-to-back and asserts the receiver sees all
+500 before `shutdown()` returns.
+
+## Lesson
+
+When a control frame ("end of stream", "drain me", "ack") shares the
+same wire as data frames, treat it as a queue-ordered event, not as a
+side channel. Out-of-band shortcuts to the socket bypass any flush
+discipline the data path is enforcing. If a side channel is genuinely
+needed (e.g. a high-priority "abort" signal), it deserves its own
+guarantees and its own test for tail losses on the data side.

--- a/docs/retrospectives/README.md
+++ b/docs/retrospectives/README.md
@@ -1,0 +1,19 @@
+# Retrospectives
+
+Postmortem-style write-ups of bugs that taught us something non-obvious
+about Goggles. Each entry should answer four questions:
+
+1. **What went wrong** — observable symptom, ideally a metric.
+2. **Root cause** — what was actually happening underneath.
+3. **Fix** — what we changed and where the regression test lives.
+4. **Lesson** — what to look for next time, or what assumption we
+   were making that turned out to be wrong.
+
+Link the retrospective from the regression test docstring so the
+historical context is one click away from the test that guards it.
+
+## Index
+
+| Date | Title | PR | Issue |
+|---|---|---|---|
+| 2026-04-20 | [Shutdown drained `BYE` before its own send queue](2026-04-shutdown-bye-flush.md) | [#143](https://github.com/antonioterpin/goggles/pull/143) | [#158](https://github.com/antonioterpin/goggles/issues/158) |

--- a/tests/core/test_transport.py
+++ b/tests/core/test_transport.py
@@ -791,7 +791,8 @@ def test_shutdown_flushes_pending_events(socket_path: str) -> None:
 
     Regresses the "77/1500 video logs arrived" bug: BYE was sent out-of-band
     during shutdown, so any frames still in the client's send queue were
-    discarded when the send thread was force-closed.
+    discarded when the send thread was force-closed. Full retrospective:
+    ``docs/retrospectives/2026-04-shutdown-bye-flush.md``.
 
     Args:
         socket_path: Endpoint path (via fixture).


### PR DESCRIPTION
## Summary
- Add `docs/retrospectives/` as the canonical home for postmortem write-ups, with a README explaining the four-question template and an index.
- Write up the "77/1500 video logs arrived" shutdown bug from PR #143 (symptom, root cause, fix, lesson).
- Link the retrospective from `test_shutdown_flushes_pending_events`'s docstring so the historical context is one click from the regression guard.

## Test plan
- [x] `uv run pytest tests/core/test_transport.py::test_shutdown_flushes_pending_events` still passes.
- [ ] Reviewer reads the retrospective and confirms the lesson is the one they would have written.

Closes #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
