### PR TITLE
fix(logger): resolve transport lazily so class-level loggers work

### DIFF
--- a/goggles/_core/logger.py
+++ b/goggles/_core/logger.py
@@ -87,7 +87,7 @@ class CoreTextLogger(TextLogger):
         class-body / module-import time (before any ``gg.attach()``)
         always route through the current bus, and so a logger that
         survives a ``gg.finish()`` -> rebuild cycle picks up the new
-        transport instead of holding a stale, closed reference. See #78.
+        transport instead of holding a stale, closed reference.
         """
         # Importing here to avoid the goggles -> routing -> goggles cycle.
         from goggles._core.routing import get_bus  # noqa: PLC0415

--- a/goggles/_core/logger.py
+++ b/goggles/_core/logger.py
@@ -74,14 +74,25 @@ class CoreTextLogger(TextLogger):
                 Optional initial persistent context to bind.
 
         """
-        # Importing here to avoid circular imports
-        from goggles._core.routing import get_bus  # noqa: PLC0415
-
         self.name = name
         self._scope = scope
         self._level = int(level)
         self._bound: dict[str, Any] = dict(**to_bind or {})
-        self._client = get_bus()
+
+    @property
+    def _client(self) -> Any:
+        """Return the live transport singleton.
+
+        Resolved lazily on every access so loggers captured at
+        class-body / module-import time (before any ``gg.attach()``)
+        always route through the current bus, and so a logger that
+        survives a ``gg.finish()`` -> rebuild cycle picks up the new
+        transport instead of holding a stale, closed reference. See #78.
+        """
+        # Importing here to avoid the goggles -> routing -> goggles cycle.
+        from goggles._core.routing import get_bus  # noqa: PLC0415
+
+        return get_bus()
 
     def set_level(self, level: int) -> None:
         """Set the minimum severity this logger will emit.

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -2,12 +2,30 @@
 
 import importlib
 import logging
+import threading
 from pathlib import Path
 from typing import ClassVar
 
 import pytest
 
 import goggles as gg
+
+
+class _ClassLevelLoggerHolder:
+    """Holder whose logger is captured at class-body time (regression #78).
+
+    The ``gg.get_logger(...)`` call happens once when this module is
+    imported by pytest, before any test body runs. That mirrors the real
+    user scenario from #78: ``logger = gg.get_logger(...)`` at class
+    scope in their own module, with ``gg.attach(...)`` called later from
+    ``main()``.
+
+    Attributes:
+        logger: Class-level Goggles text logger captured at module load.
+    """
+
+    logger = gg.get_logger("test-78-class-var", scope="global")
+
 
 # ---------------------------------------------------------------------
 # Logger creation
@@ -143,6 +161,44 @@ def test_attach_and_emit() -> None:
     assert any(
         hasattr(e, "payload") for e in DummyHandler.handled if e != "closed"
     ), "Events should have a payload attribute"
+
+
+def test_class_level_logger_does_not_hang_on_first_info() -> None:
+    """Logger captured at class-body scope must not hang on first .info().
+
+    Regression for #78: the portal-based transport could deadlock on the
+    first ``.info()`` call when the logger had been resolved early
+    (class-body time, before any ``gg.attach()``). With ``LocalTransport``
+    that pattern must complete promptly.
+
+    The emit runs on a worker thread so a hang surfaces as a timed-out
+    join rather than wedging the test runner.
+    """
+    gg.register_handler(DummyHandler)
+    DummyHandler.handled.clear()
+    handler = DummyHandler()
+    gg.attach(handler, scopes=["global"])
+
+    done = threading.Event()
+
+    def _emit() -> None:
+        _ClassLevelLoggerHolder().logger.info("class-var event")
+        done.set()
+
+    t = threading.Thread(target=_emit, daemon=True)
+    t.start()
+    assert done.wait(timeout=5.0), (
+        "class-level logger.info() did not return within 5 s — see #78"
+    )
+    gg.finish()
+    assert any(
+        getattr(e, "payload", None) == "class-var event"
+        for e in DummyHandler.handled
+        if e != "closed"
+    ), (
+        "class-level logger never delivered its event — likely a stale "
+        "transport reference captured at class-body time"
+    )
 
 
 def test_eventbus_emit_routing_and_detach():

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -342,7 +342,6 @@ def test_sync_mode_uses_emit_sync(patch_bus: MagicMock) -> None:
         patch_bus: Patched mock client fixture.
     """
     g = CoreGogglesLogger(name="sync", scope="run")
-    g._client = patch_bus
 
     g.scalar("metric", 1.0, async_mode=False)
     patch_bus.emit_sync.assert_called_once()
@@ -356,7 +355,6 @@ def test_async_mode_uses_emit(patch_bus: MagicMock) -> None:
         patch_bus: Patched mock client fixture.
     """
     g = CoreGogglesLogger(name="async", scope="run")
-    g._client = patch_bus
 
     g.scalar("metric", 1.0)
     patch_bus.emit.assert_called_once()


### PR DESCRIPTION
## Summary
The class-level pattern users hit in #78

```python
class Foo:
    logger = gg.get_logger(__name__)
```

evaluates `get_logger(...)` at class-body time, before user code runs `gg.attach(...)`. With the old eager `self._client = get_bus()` in `CoreTextLogger.__init__`, the logger captured whatever transport existed at that moment.

The original symptom (hang on the first `.info()`) was already fixed by #143's portal removal. A quieter residual remained: a logger captured before the bus was rebuilt — or before `gg.finish()` reset it — silently dropped every event because `_client` pointed at a closed transport. The new regression test demonstrates this on the pre-fix code: `test_class_level_logger_does_not_hang_on_first_info` passes in isolation but fails when ordered after another test that calls `gg.finish()`.

## Fix
Make `_client` a `@property` that delegates to `goggles._core.routing.get_bus()` on every access. The routing singleton already has a "rebuild if dead" path, so each emit reads the live transport. Cost is one function call + a module-global lookup per emit; nothing measurable for log-rate workloads.

## Test plan
- [x] `tests/core/test_api.py::test_class_level_logger_does_not_hang_on_first_info` reproduces the exact #78 shape: class-scope `gg.get_logger(...)`, `.info()` on a worker thread (so a real hang surfaces as a timed-out join), and asserts the handler received the event.
- [x] `uv run pytest` — 575 passed, 4 skipped (existing skips).
- [x] `uv run pre-commit run --all-files --hook-stage pre-push` — basedpyright + pytest pass.
- [x] Dropped now-redundant `g._client = patch_bus` in two `test_logger.py` fixtures: the `patch_bus` fixture already monkeypatches `get_bus()`, so the property reads the mock automatically.

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
