### PR TITLE
feat(api): add configure() shortcut for the common console-only setup

### DIFF
--- a/goggles/__init__.py
+++ b/goggles/__init__.py
@@ -35,6 +35,7 @@ import os
 import threading
 from collections import defaultdict
 from collections.abc import Callable
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -977,6 +978,55 @@ def attach(handler: Handler, scopes: list[str] | None = None) -> None:
         scopes = ["global"]
     bus = get_bus()
     bus.attach(handlers=[handler.to_dict()], scopes=scopes)
+
+
+def configure(
+    *,
+    enable_console: bool = False,
+    console_level: int = logging.INFO,
+    console_path_style: Literal["absolute", "relative"] = "relative",
+    project_root: str | os.PathLike[str] | None = None,
+    scopes: list[str] | None = None,
+) -> None:
+    """One-call shortcut for the common "I just want a console logger" setup.
+
+    Replaces the boilerplate
+
+        gg.attach(gg.ConsoleHandler(level=logging.INFO), scopes=["global"])
+
+    with
+
+        gg.configure(enable_console=True)
+
+    Power users should keep using ``attach`` / handler classes directly —
+    this helper only covers the standard cases. Calling it with no arguments
+    is a no-op so it is safe to invoke unconditionally during library
+    initialisation. See issue #43.
+
+    Args:
+        enable_console: When True, attach a default ``ConsoleHandler``
+            under ``scopes``. When False (the default), this argument
+            does nothing.
+        console_level: Minimum level for the auto-attached console
+            handler. Ignored when ``enable_console`` is False.
+        console_path_style: Whether the console handler prints absolute
+            or project-relative source paths. Ignored when
+            ``enable_console`` is False.
+        project_root: Root path used to compute relative paths. Defaults
+            to the current working directory.
+        scopes: Scopes under which to attach the console handler.
+            Defaults to ``["global"]``.
+    """
+    if not enable_console:
+        return
+    if scopes is None:
+        scopes = ["global"]
+    handler = ConsoleHandler(
+        level=console_level,
+        path_style=console_path_style,
+        project_root=Path(project_root) if project_root is not None else None,
+    )
+    attach(handler, scopes=scopes)
 
 
 def detach(handler_name: str, scope: str) -> None:

--- a/goggles/__init__.py
+++ b/goggles/__init__.py
@@ -998,10 +998,15 @@ def configure(
 
         gg.configure(enable_console=True)
 
-    Power users should keep using ``attach`` / handler classes directly —
+    Power users should keep using ``attach`` / handler classes directly --
     this helper only covers the standard cases. Calling it with no arguments
     is a no-op so it is safe to invoke unconditionally during library
-    initialisation. See issue #43.
+    initialization.
+
+    Calling ``configure(enable_console=True, ...)`` while a console handler
+    is already attached will detach the existing handler from every scope
+    it is bound to and attach a fresh one with the new options, so the
+    second call wins instead of being silently deduped by name.
 
     Args:
         enable_console: When True, attach a default ``ConsoleHandler``
@@ -1021,6 +1026,23 @@ def configure(
         return
     if scopes is None:
         scopes = ["global"]
+
+    # Replace any existing console handler so a second `configure(...)` call
+    # with new options actually takes effect (`attach()` dedupes by name and
+    # would otherwise silently keep the first instance).
+    internal_bus = cast(Any, get_bus())._bus
+    existing_scopes = [
+        s
+        for s, names in list(internal_bus.scopes.items())
+        if ConsoleHandler.name in names
+    ]
+    for s in existing_scopes:
+        try:
+            detach(ConsoleHandler.name, s)
+        except ValueError:
+            # Already detached by a concurrent caller; nothing to do.
+            pass
+
     handler = ConsoleHandler(
         level=console_level,
         path_style=console_path_style,

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -4,7 +4,7 @@ import importlib
 import logging
 import threading
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar, cast
 
 import pytest
 
@@ -158,6 +158,60 @@ def test_attach_and_emit() -> None:
     assert any(
         hasattr(e, "payload") for e in DummyHandler.handled if e != "closed"
     ), "Events should have a payload attribute"
+
+
+def _scoped_handlers() -> dict:
+    """Snapshot of (scope -> set of handler names) on the host bus."""
+    transport = cast("Any", gg.get_bus())
+    return dict(transport._bus.scopes)
+
+
+def _bus_handlers() -> dict:
+    """Snapshot of (handler name -> handler instance) on the host bus."""
+    transport = cast("Any", gg.get_bus())
+    return dict(transport._bus.handlers)
+
+
+def test_configure_is_noop_by_default() -> None:
+    """configure() with no args attaches nothing — purely a shortcut."""
+    gg.finish()  # clean slate
+    before = _scoped_handlers()
+    gg.configure()
+    assert _scoped_handlers() == before, (
+        "configure() with default args must not change the bus state"
+    )
+    gg.finish()
+
+
+def test_configure_enable_console_attaches_console_handler() -> None:
+    """configure(enable_console=True) wires a ConsoleHandler on global."""
+    gg.finish()
+    gg.configure(enable_console=True, console_level=logging.WARNING)
+    assert "global" in _scoped_handlers(), (
+        "configure(enable_console=True) should attach to 'global' by default"
+    )
+    consoles = [
+        h for h in _bus_handlers().values() if isinstance(h, gg.ConsoleHandler)
+    ]
+    assert len(consoles) == 1, (
+        f"Expected exactly one ConsoleHandler, found {len(consoles)}"
+    )
+    assert consoles[0].level == logging.WARNING, (
+        "console_level should propagate to the handler"
+    )
+    gg.finish()
+
+
+def test_configure_respects_scopes_argument() -> None:
+    """A custom scopes list routes the auto-attached handler accordingly."""
+    gg.finish()
+    gg.configure(enable_console=True, scopes=["train", "eval"])
+    scopes = _scoped_handlers()
+    for s in ("train", "eval"):
+        assert s in scopes, (
+            f"configure(scopes=[..., '{s}']) must attach under scope '{s}'"
+        )
+    gg.finish()
 
 
 def test_class_level_logger_does_not_hang_on_first_info() -> None:

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -162,56 +162,97 @@ def test_attach_and_emit() -> None:
 
 def _scoped_handlers() -> dict:
     """Snapshot of (scope -> set of handler names) on the host bus."""
-    transport = cast("Any", gg.get_bus())
+    transport = cast(Any, gg.get_bus())
     return dict(transport._bus.scopes)
 
 
 def _bus_handlers() -> dict:
     """Snapshot of (handler name -> handler instance) on the host bus."""
-    transport = cast("Any", gg.get_bus())
+    transport = cast(Any, gg.get_bus())
     return dict(transport._bus.handlers)
 
 
 def test_configure_is_noop_by_default() -> None:
     """configure() with no args attaches nothing — purely a shortcut."""
     gg.finish()  # clean slate
-    before = _scoped_handlers()
-    gg.configure()
-    assert _scoped_handlers() == before, (
-        "configure() with default args must not change the bus state"
-    )
-    gg.finish()
+    try:
+        before = _scoped_handlers()
+        gg.configure()
+        assert _scoped_handlers() == before, (
+            "configure() with default args must not change the bus state"
+        )
+    finally:
+        gg.finish()
 
 
 def test_configure_enable_console_attaches_console_handler() -> None:
     """configure(enable_console=True) wires a ConsoleHandler on global."""
     gg.finish()
-    gg.configure(enable_console=True, console_level=logging.WARNING)
-    assert "global" in _scoped_handlers(), (
-        "configure(enable_console=True) should attach to 'global' by default"
-    )
-    consoles = [
-        h for h in _bus_handlers().values() if isinstance(h, gg.ConsoleHandler)
-    ]
-    assert len(consoles) == 1, (
-        f"Expected exactly one ConsoleHandler, found {len(consoles)}"
-    )
-    assert consoles[0].level == logging.WARNING, (
-        "console_level should propagate to the handler"
-    )
-    gg.finish()
+    try:
+        gg.configure(enable_console=True, console_level=logging.WARNING)
+        assert "global" in _scoped_handlers(), (
+            "configure(enable_console=True) should attach to 'global' by "
+            "default"
+        )
+        consoles = [
+            h
+            for h in _bus_handlers().values()
+            if isinstance(h, gg.ConsoleHandler)
+        ]
+        assert len(consoles) == 1, (
+            f"Expected exactly one ConsoleHandler, found {len(consoles)}"
+        )
+        assert consoles[0].level == logging.WARNING, (
+            "console_level should propagate to the handler"
+        )
+    finally:
+        gg.finish()
 
 
 def test_configure_respects_scopes_argument() -> None:
     """A custom scopes list routes the auto-attached handler accordingly."""
     gg.finish()
-    gg.configure(enable_console=True, scopes=["train", "eval"])
-    scopes = _scoped_handlers()
-    for s in ("train", "eval"):
-        assert s in scopes, (
-            f"configure(scopes=[..., '{s}']) must attach under scope '{s}'"
-        )
+    try:
+        gg.configure(enable_console=True, scopes=["train", "eval"])
+        scopes = _scoped_handlers()
+        for s in ("train", "eval"):
+            assert s in scopes, (
+                f"configure(scopes=[..., '{s}']) must attach under scope '{s}'"
+            )
+    finally:
+        gg.finish()
+
+
+def test_configure_replaces_existing_console_handler() -> None:
+    """A second configure() call swaps the console handler instance."""
     gg.finish()
+    try:
+        gg.configure(enable_console=True, console_level=logging.INFO)
+        first = next(
+            h
+            for h in _bus_handlers().values()
+            if isinstance(h, gg.ConsoleHandler)
+        )
+        gg.configure(enable_console=True, console_level=logging.WARNING)
+        consoles = [
+            h
+            for h in _bus_handlers().values()
+            if isinstance(h, gg.ConsoleHandler)
+        ]
+        assert len(consoles) == 1, (
+            f"Reconfigure must keep exactly one console handler; "
+            f"saw {len(consoles)}"
+        )
+        assert consoles[0] is not first, (
+            "Reconfigure must install a new ConsoleHandler instance, "
+            "not silently keep the first one"
+        )
+        assert consoles[0].level == logging.WARNING, (
+            "Reconfigure must apply the new console_level (saw "
+            f"{consoles[0].level})"
+        )
+    finally:
+        gg.finish()
 
 
 def test_class_level_logger_does_not_hang_on_first_info() -> None:


### PR DESCRIPTION
## Summary
Add `gg.configure(enable_console=True, ...)` so the common "I just want a console logger" path collapses from

```python
gg.attach(gg.ConsoleHandler(level=logging.INFO), scopes=["global"])
```

to

```python
gg.configure(enable_console=True)
```

Calling `configure()` with no arguments is a no-op, so libraries can invoke it unconditionally without surprising users. Power users keep using `attach` / handler classes directly — this helper only covers the standard cases.

API:
```python
def configure(
    *,
    enable_console: bool = False,
    console_level: int = logging.INFO,
    console_path_style: Literal["absolute", "relative"] = "relative",
    project_root: str | os.PathLike[str] | None = None,
    scopes: list[str] | None = None,
) -> None
```

## Test plan
- [x] `tests/core/test_api.py::test_configure_is_noop_by_default` — bus state unchanged when called with defaults.
- [x] `tests/core/test_api.py::test_configure_enable_console_attaches_console_handler` — exactly one `ConsoleHandler` attached on `global`, with the right level.
- [x] `tests/core/test_api.py::test_configure_respects_scopes_argument` — custom scopes honored.
- [x] `uv run pytest` — 586 passed, 4 skipped.
- [x] `uv run pre-commit run --all-files --hook-stage pre-push` — clean (basedpyright, ruff, pydoclint, pytest).

Picks up a one-line formatter cleanup in `test_step_guard.py` that pre-push touched on this branch.

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
