### PR TITLE
feat(logger): per-logger set_level + level kwarg on get_logger

### DIFF
--- a/goggles/__init__.py
+++ b/goggles/__init__.py
@@ -160,23 +160,25 @@ def freeze() -> None:
 def _make_text_logger(
     name: str | None,
     scope: str,
+    level: int,
     **to_bind: Any,
 ) -> TextLogger:
     # Importing here to avoid circular imports
     from ._core.logger import CoreTextLogger  # noqa: PLC0415
 
-    return CoreTextLogger(name=name, scope=scope, **to_bind)
+    return CoreTextLogger(name=name, scope=scope, level=level, **to_bind)
 
 
 def _make_goggles_logger(
     name: str | None,
     scope: str,
+    level: int,
     **to_bind: Any,
 ) -> GogglesLogger:
     # Importing here to avoid circular imports
     from ._core.logger import CoreGogglesLogger  # noqa: PLC0415
 
-    return CoreGogglesLogger(name=name, scope=scope, **to_bind)
+    return CoreGogglesLogger(name=name, scope=scope, level=level, **to_bind)
 
 
 # ---------------------------------------------------------------------------
@@ -191,6 +193,7 @@ def get_logger(
     *,
     with_metrics: Literal[False] = False,
     scope: str = "global",
+    level: int = logging.NOTSET,
     **to_bind: Any,
 ) -> TextLogger: ...
 
@@ -202,6 +205,7 @@ def get_logger(
     *,
     with_metrics: Literal[True],
     scope: str = "global",
+    level: int = logging.NOTSET,
     **to_bind: Any,
 ) -> GogglesLogger: ...
 
@@ -212,6 +216,7 @@ def get_logger(
     *,
     with_metrics: bool = False,
     scope: str = "global",
+    level: int = logging.NOTSET,
     **to_bind: Any,
 ) -> TextLogger | GogglesLogger:
     """Return a structured logger.
@@ -229,6 +234,11 @@ def get_logger(
         name: Logger name. If None, the root logger is used.
         with_metrics: If True, return a logger exposing `.metrics`.
         scope: The logging scope, e.g., "global" or "run".
+        level: Minimum severity this logger will emit. Defaults to
+            ``logging.NOTSET`` (emit everything); pass
+            ``logging.DEBUG`` / ``logging.INFO`` / etc. to drop
+            lower-severity records at the source. Also settable later
+            via ``logger.set_level(...)``.
         **to_bind: Fields persisted and injected into every record.
 
     Returns:
@@ -243,12 +253,16 @@ def get_logger(
         >>> # Explicit metrics surface
         >>> tlog = get_logger("train", with_metrics=True, seed=0)
         >>> tlog.scalar("loss", 0.42, step=1)
+        >>>
+        >>> # Per-file DEBUG without flooding the rest of the app.
+        >>> dbg = get_logger(__name__, level=logging.DEBUG)
+        >>> dbg.debug("detailed trace")
 
     """
     if with_metrics:
-        return _make_goggles_logger(name, scope, **to_bind)
+        return _make_goggles_logger(name, scope, level, **to_bind)
     else:
-        return _make_text_logger(name, scope, **to_bind)
+        return _make_text_logger(name, scope, level, **to_bind)
 
 
 @runtime_checkable
@@ -279,6 +293,19 @@ class TextLogger(Protocol):
         Returns:
             New logger instance with persistent fields.
 
+        """
+        ...
+
+    def set_level(self, level: int) -> None:
+        """Set the minimum severity this logger will emit.
+
+        Calls below ``level`` are dropped before reaching the transport.
+        Only affects this logger instance; sibling loggers obtained via
+        separate ``get_logger(...)`` calls are unaffected.
+
+        Args:
+            level: Standard ``logging`` level (e.g. ``logging.DEBUG``).
+                ``logging.NOTSET`` (the default) forwards every call.
         """
         ...
 

--- a/goggles/_core/logger.py
+++ b/goggles/_core/logger.py
@@ -58,6 +58,7 @@ class CoreTextLogger(TextLogger):
         self,
         scope: str,
         name: str | None = None,
+        level: int = logging.NOTSET,
         **to_bind: Any,
     ):
         """Initialize the CoreTextLogger.
@@ -65,6 +66,10 @@ class CoreTextLogger(TextLogger):
         Args:
             scope: Scope to bind the logger to (e.g., "global", "run", etc.).
             name: Optional name of the logger.
+            level: Minimum severity (standard ``logging`` levels) that this
+                logger will emit. Calls below this threshold are dropped
+                before touching the transport. ``logging.NOTSET`` (the
+                default) forwards every call.
             **to_bind:
                 Optional initial persistent context to bind.
 
@@ -74,8 +79,32 @@ class CoreTextLogger(TextLogger):
 
         self.name = name
         self._scope = scope
+        self._level = int(level)
         self._bound: dict[str, Any] = dict(**to_bind or {})
         self._client = get_bus()
+
+    def set_level(self, level: int) -> None:
+        """Set the minimum severity this logger will emit.
+
+        Calls below this threshold are dropped before touching the
+        transport. Only affects this logger instance — sibling loggers
+        obtained via separate ``get_logger(...)`` calls are untouched.
+
+        Args:
+            level: Standard ``logging`` level (e.g. ``logging.DEBUG``).
+        """
+        self._level = int(level)
+
+    def _below_level(self, severity: int) -> bool:
+        """Return whether ``severity`` is below the configured gate.
+
+        Args:
+            severity: Standard ``logging`` level of the call being made.
+
+        Returns:
+            ``True`` if the call should be dropped, ``False`` otherwise.
+        """
+        return self._level != logging.NOTSET and severity < self._level
 
     def _dispatch(self, event: Event, *, async_mode: bool) -> None:
         """Route ``event`` through the transport.
@@ -118,6 +147,7 @@ class CoreTextLogger(TextLogger):
         return self.__class__(
             scope=scope,
             name=self.name,
+            level=self._level,
             **{**self._bound, **fields},
         )
 
@@ -150,6 +180,8 @@ class CoreTextLogger(TextLogger):
             **extra: Per-call structured fields merged with the bound context.
 
         """
+        if self._below_level(logging.DEBUG):
+            return
         filepath, lineno = _caller_id()
         self._dispatch(
             Event(
@@ -186,6 +218,8 @@ class CoreTextLogger(TextLogger):
             **extra: Additional structured key-value pairs for this record.
 
         """
+        if self._below_level(logging.INFO):
+            return
         filepath, lineno = _caller_id()
         self._dispatch(
             Event(
@@ -222,6 +256,8 @@ class CoreTextLogger(TextLogger):
             **extra: Per-call structured fields merged with the bound context.
 
         """
+        if self._below_level(logging.WARNING):
+            return
         filepath, lineno = _caller_id()
         self._dispatch(
             Event(
@@ -258,6 +294,8 @@ class CoreTextLogger(TextLogger):
             **extra: Per-call structured fields merged with the bound context.
 
         """
+        if self._below_level(logging.ERROR):
+            return
         filepath, lineno = _caller_id()
         self._dispatch(
             Event(
@@ -294,6 +332,8 @@ class CoreTextLogger(TextLogger):
             **extra: Per-call structured fields merged with the bound context.
 
         """
+        if self._below_level(logging.CRITICAL):
+            return
         filepath, lineno = _caller_id()
         self._dispatch(
             Event(

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -68,7 +68,12 @@ def goggles_logger(patch_bus: MagicMock) -> CoreGogglesLogger:
 # -------------------------------------------------------------------------
 
 
-def test_bind_creates_new_context(text_logger):
+def test_bind_creates_new_context(text_logger: CoreTextLogger) -> None:
+    """``bind`` returns a derived adapter with merged persistent fields.
+
+    Args:
+        text_logger: ``CoreTextLogger`` fixture.
+    """
     text_logger._bound = {"old": 1}
     bound_logger = text_logger.bind(scope="run", new=2)
     assert bound_logger.get_bound() == {
@@ -88,7 +93,20 @@ def test_bind_creates_new_context(text_logger):
         (logging.CRITICAL, "critical"),
     ],
 )
-def test_log_methods_emit_event(text_logger, patch_bus, level, method):
+def test_log_methods_emit_event(
+    text_logger: CoreTextLogger,
+    patch_bus: MagicMock,
+    level: int,
+    method: str,
+) -> None:
+    """Each severity method emits an event whose level matches.
+
+    Args:
+        text_logger: ``CoreTextLogger`` fixture.
+        patch_bus: Patched mock client fixture.
+        level: Standard logging level the method should stamp on the event.
+        method: Name of the level method to invoke (``debug``, ``info``, ...).
+    """
     msg = f"message-{method}"
     getattr(text_logger, method)(msg, step=1, time=123.0, extra_field="x")
     assert patch_bus.emit.called, "patch_bus.emit should have been called"
@@ -100,7 +118,12 @@ def test_log_methods_emit_event(text_logger, patch_bus, level, method):
     assert event.extra["extra_field"] == "x", "Event extra field mismatch"
 
 
-def test_repr_includes_name_and_bound(text_logger):
+def test_repr_includes_name_and_bound(text_logger: CoreTextLogger) -> None:
+    """``repr`` carries the class, the logger name, and the bound keys.
+
+    Args:
+        text_logger: ``CoreTextLogger`` fixture.
+    """
     text_logger._bound = {"a": 1}
     rep = repr(text_logger)
     assert "CoreTextLogger" in rep, "repr should include class name"
@@ -113,7 +136,15 @@ def test_repr_includes_name_and_bound(text_logger):
 # -------------------------------------------------------------------------
 
 
-def test_push_emits_metric_event(goggles_logger, patch_bus):
+def test_push_emits_metric_event(
+    goggles_logger: CoreGogglesLogger, patch_bus: MagicMock
+) -> None:
+    """``push`` emits a metric event carrying the dict payload + step.
+
+    Args:
+        goggles_logger: ``CoreGogglesLogger`` fixture.
+        patch_bus: Patched mock client fixture.
+    """
     metrics = {"loss": 0.1, "acc": 0.9}
     goggles_logger.push(metrics, step=2)
     event = patch_bus.emit.call_args[0][0]
@@ -122,7 +153,15 @@ def test_push_emits_metric_event(goggles_logger, patch_bus):
     assert event.step == 2, "Event step mismatch"
 
 
-def test_scalar_emits_metric_event(goggles_logger, patch_bus):
+def test_scalar_emits_metric_event(
+    goggles_logger: CoreGogglesLogger, patch_bus: MagicMock
+) -> None:
+    """``scalar`` emits a metric event keyed by the metric name.
+
+    Args:
+        goggles_logger: ``CoreGogglesLogger`` fixture.
+        patch_bus: Patched mock client fixture.
+    """
     goggles_logger.scalar("loss", 0.42)
     event = patch_bus.emit.call_args[0][0]
     assert event.kind == "metric", "Event kind should be 'metric' for scalar"
@@ -143,8 +182,22 @@ def test_scalar_emits_metric_event(goggles_logger, patch_bus):
     ],
 )
 def test_artifact_like_methods_emit_event(
-    goggles_logger, patch_bus, kind, method, arg_key
-):
+    goggles_logger: CoreGogglesLogger,
+    patch_bus: MagicMock,
+    kind: str,
+    method: str,
+    arg_key: str,
+) -> None:
+    """Each artifact-like method emits an event of the matching kind.
+
+    Args:
+        goggles_logger: ``CoreGogglesLogger`` fixture.
+        patch_bus: Patched mock client fixture.
+        kind: Expected ``event.kind`` after the call.
+        method: Logger method to invoke.
+        arg_key: Unused — present for parametrize symmetry.
+    """
+    del arg_key
     fake_payload = SimpleNamespace(dummy=True)
     kwargs = {}
     if method == "video":
@@ -159,7 +212,15 @@ def test_artifact_like_methods_emit_event(
     assert event.extra["name"] == "foo", "Event extra 'name' mismatch"
 
 
-def test_histogram_adds_name_and_payload(goggles_logger, patch_bus):
+def test_histogram_adds_name_and_payload(
+    goggles_logger: CoreGogglesLogger, patch_bus: MagicMock
+) -> None:
+    """``histogram`` emits an event with ``extra['name']`` and payload set.
+
+    Args:
+        goggles_logger: ``CoreGogglesLogger`` fixture.
+        patch_bus: Patched mock client fixture.
+    """
     goggles_logger.histogram([1, 2, 3], name="hist", step=1)
     event = patch_bus.emit.call_args[0][0]
     assert event.kind == "histogram", "Event kind should be 'histogram'"
@@ -200,12 +261,23 @@ def test_async_mode_uses_emit(patch_bus: MagicMock) -> None:
 def test_default_level_emits_all_severities(
     text_logger: CoreTextLogger, patch_bus: MagicMock
 ) -> None:
+    """With the default ``NOTSET`` gate every severity reaches the bus.
+
+    Args:
+        text_logger: ``CoreTextLogger`` fixture.
+        patch_bus: Patched mock client fixture.
+    """
     for method in ("debug", "info", "warning", "error", "critical"):
         getattr(text_logger, method)("x")
     assert patch_bus.emit.call_count == 5
 
 
 def test_set_level_drops_below_threshold(patch_bus: MagicMock) -> None:
+    """``set_level`` drops calls below the threshold and forwards the rest.
+
+    Args:
+        patch_bus: Patched mock client fixture.
+    """
     logger = CoreTextLogger(name="t", scope="global")
     logger.set_level(logging.INFO)
 
@@ -220,6 +292,11 @@ def test_set_level_drops_below_threshold(patch_bus: MagicMock) -> None:
 def test_set_level_warning_drops_info_and_debug(
     patch_bus: MagicMock,
 ) -> None:
+    """At ``WARNING`` only WARNING and above propagate.
+
+    Args:
+        patch_bus: Patched mock client fixture.
+    """
     logger = CoreTextLogger(name="t", scope="global")
     logger.set_level(logging.WARNING)
 
@@ -234,6 +311,11 @@ def test_set_level_warning_drops_info_and_debug(
 
 
 def test_level_via_constructor(patch_bus: MagicMock) -> None:
+    """Constructor-time ``level=`` is honoured the same as ``set_level``.
+
+    Args:
+        patch_bus: Patched mock client fixture.
+    """
     logger = CoreTextLogger(name="t", scope="global", level=logging.WARNING)
     logger.info("drop")
     logger.warning("keep")
@@ -241,6 +323,11 @@ def test_level_via_constructor(patch_bus: MagicMock) -> None:
 
 
 def test_bind_preserves_level(patch_bus: MagicMock) -> None:
+    """``bind`` carries the parent level into the derived adapter.
+
+    Args:
+        patch_bus: Patched mock client fixture.
+    """
     logger = CoreTextLogger(name="t", scope="global", level=logging.WARNING)
     child = logger.bind(scope="run", k=1)
     child.info("drop")
@@ -249,6 +336,11 @@ def test_bind_preserves_level(patch_bus: MagicMock) -> None:
 
 
 def test_set_level_is_logger_local(patch_bus: MagicMock) -> None:
+    """``set_level`` only mutates the logger it's called on.
+
+    Args:
+        patch_bus: Patched mock client fixture.
+    """
     quiet = CoreTextLogger(name="quiet", scope="global")
     quiet.set_level(logging.WARNING)
 
@@ -260,6 +352,11 @@ def test_set_level_is_logger_local(patch_bus: MagicMock) -> None:
 
 
 def test_get_logger_level_kwarg(patch_bus: MagicMock) -> None:
+    """``gg.get_logger(..., level=...)`` propagates to the logger gate.
+
+    Args:
+        patch_bus: Patched mock client fixture.
+    """
     import goggles as gg  # noqa: PLC0415
 
     logger = gg.get_logger("x", level=logging.WARNING)

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -195,3 +195,74 @@ def test_async_mode_uses_emit(patch_bus: MagicMock) -> None:
     g.scalar("metric", 1.0)
     patch_bus.emit.assert_called_once()
     patch_bus.emit_sync.assert_not_called()
+
+
+def test_default_level_emits_all_severities(
+    text_logger: CoreTextLogger, patch_bus: MagicMock
+) -> None:
+    for method in ("debug", "info", "warning", "error", "critical"):
+        getattr(text_logger, method)("x")
+    assert patch_bus.emit.call_count == 5
+
+
+def test_set_level_drops_below_threshold(patch_bus: MagicMock) -> None:
+    logger = CoreTextLogger(name="t", scope="global")
+    logger.set_level(logging.INFO)
+
+    logger.debug("drop")
+    assert patch_bus.emit.call_count == 0
+
+    logger.info("keep")
+    logger.warning("keep")
+    assert patch_bus.emit.call_count == 2
+
+
+def test_set_level_warning_drops_info_and_debug(
+    patch_bus: MagicMock,
+) -> None:
+    logger = CoreTextLogger(name="t", scope="global")
+    logger.set_level(logging.WARNING)
+
+    logger.debug("drop")
+    logger.info("drop")
+    assert patch_bus.emit.call_count == 0
+
+    logger.warning("keep")
+    logger.error("keep")
+    logger.critical("keep")
+    assert patch_bus.emit.call_count == 3
+
+
+def test_level_via_constructor(patch_bus: MagicMock) -> None:
+    logger = CoreTextLogger(name="t", scope="global", level=logging.WARNING)
+    logger.info("drop")
+    logger.warning("keep")
+    assert patch_bus.emit.call_count == 1
+
+
+def test_bind_preserves_level(patch_bus: MagicMock) -> None:
+    logger = CoreTextLogger(name="t", scope="global", level=logging.WARNING)
+    child = logger.bind(scope="run", k=1)
+    child.info("drop")
+    child.warning("keep")
+    assert patch_bus.emit.call_count == 1
+
+
+def test_set_level_is_logger_local(patch_bus: MagicMock) -> None:
+    quiet = CoreTextLogger(name="quiet", scope="global")
+    quiet.set_level(logging.WARNING)
+
+    loud = CoreTextLogger(name="loud", scope="global")
+
+    quiet.debug("drop")
+    loud.debug("keep")
+    assert patch_bus.emit.call_count == 1
+
+
+def test_get_logger_level_kwarg(patch_bus: MagicMock) -> None:
+    import goggles as gg  # noqa: PLC0415
+
+    logger = gg.get_logger("x", level=logging.WARNING)
+    logger.info("drop")
+    logger.warning("keep")
+    assert patch_bus.emit.call_count == 1

--- a/tests/test_top_level_api.py
+++ b/tests/test_top_level_api.py
@@ -68,9 +68,11 @@ def clean_registry(monkeypatch):
 def test_get_logger_returns_text_and_goggles(monkeypatch):
     dummy_text = object()
     dummy_metrics = object()
-    monkeypatch.setattr(gg, "_make_text_logger", lambda n, s, **t: dummy_text)
     monkeypatch.setattr(
-        gg, "_make_goggles_logger", lambda n, s, **t: dummy_metrics
+        gg, "_make_text_logger", lambda n, s, level, **t: dummy_text
+    )
+    monkeypatch.setattr(
+        gg, "_make_goggles_logger", lambda n, s, level, **t: dummy_metrics
     )
 
     assert gg.get_logger("x") is dummy_text, (


### PR DESCRIPTION
## Summary
- Add a `set_level(...)` method to `GogglesLogger` so callers can adjust verbosity on a per-logger basis after instantiation.
- Accept a `level=` kwarg on `get_logger(...)` so the level can be set at construction time.
- Backfill Google-style docstrings on `tests/core/test_logger.py`.

> Re-opened from #151 — the original was mistakenly merged into a stale base branch (`feat-137-apply-overrides`) and the commits never reached `dev`. Branch rebased onto current `dev` (#150 squash-merged duplicate dropped).

## Test plan
- [x] \`uv run pytest tests/core/test_logger.py\`
- [x] \`uv run pre-commit run --all-files --hook-stage pre-push\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)