### PR TITLE
feat(wandb): apply per-scope monotonic-step guard to WandBHandler

### DIFF
--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -14,6 +14,8 @@ import wandb
 from goggles.media import create_numpy_vector_field_visualization
 from goggles.types import Kind
 
+from ._step_guard import StepGuard
+
 
 def create_plotly_trajectories_figure(trajectories: np.ndarray) -> Any:
     """Render trajectories as an interactive Plotly figure.
@@ -176,6 +178,12 @@ class WandBHandler:
     explicitly closed. Compatible with the `Handler` protocol used by the
     EventBus.
 
+    Out-of-order steps (``event.step`` strictly less than the highest step
+    previously seen on the same scope) are dropped with a warning, so the
+    W&B run timeline is non-decreasing per scope. Events with
+    ``step is None`` are forwarded unchanged. Artifact events are
+    step-less and bypass the check.
+
     Attributes:
         name: Stable handler identifier.
         capabilities: Supported event kinds
@@ -250,6 +258,7 @@ class WandBHandler:
         self._runs: dict[str, Run] = {}
         self._wandb_run: Run | None = None
         self._current_scope: str | None = None
+        self._step_guard = StepGuard()
 
     def can_handle(self, kind: str) -> bool:
         """Return True if the handler supports this event kind.
@@ -276,6 +285,17 @@ class WandBHandler:
         kind = getattr(event, "kind", None) or "metric"
         step = getattr(event, "step", None)
         payload = getattr(event, "payload", None)
+
+        # Artifacts are step-less and bypass the monotonic-step check.
+        if kind != "artifact" and self._step_guard.check(scope, step):
+            self._logger.warning(
+                "Dropping out-of-order event (scope=%s, step=%s) -- "
+                "step regressed below previously seen max",
+                scope,
+                step,
+            )
+            return
+
         # Copy so our .pop(...) calls don't mutate the shared event.extra
         # that other handlers on the same bus will read afterwards.
         extra = dict(getattr(event, "extra", {}) or {})

--- a/tests/core/integrations/test_wandb.py
+++ b/tests/core/integrations/test_wandb.py
@@ -30,7 +30,12 @@ def mock_wandb(monkeypatch):
     return mock
 
 
-def make_event(kind="metric", scope="global", payload=None, step=0):
+def make_event(
+    kind="metric",
+    scope="global",
+    payload=None,
+    step: int | None = 0,
+):
     return SimpleNamespace(kind=kind, scope=scope, payload=payload, step=step)
 
 
@@ -378,3 +383,100 @@ def test_prepare_video_channels_first_grayscale_repeated():
     value = np.full((F, 1, H, W), 128, dtype=np.uint8)
     out = h._prepare_video_for_wandb(value)
     assert out.shape == (F, 3, H, W)
+
+
+# -------------------------------------------------------------------------
+# Monotonic-step contract
+# -------------------------------------------------------------------------
+
+
+def test_handle_drops_backward_step_with_warning(mock_wandb):
+    """Backward step within a scope is dropped before any wandb call."""
+    h = WandBHandler(project="proj")
+    e1 = make_event(kind="metric", payload={"loss": 1.0}, step=10)
+    e2 = make_event(kind="metric", payload={"loss": 0.9}, step=5)
+
+    messages, collector = _capture_logger_messages(h._logger)
+    try:
+        h.handle(e1)
+        h.handle(e2)
+    finally:
+        h._logger.removeHandler(collector)
+
+    run = mock_wandb.init.return_value
+    assert run.log.call_count == 1, (
+        "Backward-step event must not reach run.log; "
+        f"saw {run.log.call_count} calls"
+    )
+    assert run.log.call_args.kwargs["step"] == 10, (
+        "Only the forward-step event should have been logged"
+    )
+    assert any(
+        "out-of-order" in m.lower() and "step=5" in m for m in messages
+    ), "Should warn that step=5 regressed"
+
+
+def test_handle_allows_equal_and_forward_steps(mock_wandb):
+    """Equal and forward steps within the same scope are forwarded to wandb."""
+    h = WandBHandler(project="proj")
+    h.handle(make_event(kind="metric", payload={"a": 1}, step=3))
+    h.handle(make_event(kind="metric", payload={"b": 2}, step=3))  # equal
+    h.handle(make_event(kind="metric", payload={"c": 3}, step=4))  # forward
+
+    run = mock_wandb.init.return_value
+    assert run.log.call_count == 3, (
+        f"Expected 3 wandb.log calls; saw {run.log.call_count}"
+    )
+
+
+def test_handle_tracks_step_per_scope(mock_wandb):
+    """Step monotonicity is tracked per scope, not globally."""
+    h = WandBHandler(project="proj")
+    h.handle(
+        make_event(kind="metric", payload={"x": 1}, scope="train", step=10)
+    )
+    # Lower step on a different scope must still be forwarded.
+    h.handle(make_event(kind="metric", payload={"x": 2}, scope="eval", step=1))
+
+    # mock_wandb.init returns the same MagicMock for every scope, so both
+    # scopes share the same .log mock; assert on total calls instead.
+    run = mock_wandb.init.return_value
+    assert run.log.call_count == 2, (
+        f"both scopes' events should have been forwarded; "
+        f"saw {run.log.call_count} log calls"
+    )
+
+
+def test_handle_does_not_guard_when_step_is_none(mock_wandb):
+    """Events with step=None never trip the guard, even after a regression."""
+    h = WandBHandler(project="proj")
+    h.handle(make_event(kind="metric", payload={"a": 1}, step=10))
+    # step=None must not be flagged.
+    h.handle(make_event(kind="metric", payload={"b": 2}, step=None))
+
+    run = mock_wandb.init.return_value
+    assert run.log.call_count == 2, (
+        f"step=None must not be dropped; saw {run.log.call_count} calls"
+    )
+
+
+def test_handle_artifact_bypasses_step_guard(mock_wandb, tmp_path):
+    """Artifacts are step-less and must bypass the monotonic-step check."""
+    artifact_file = tmp_path / "a.npy"
+    artifact_file.write_bytes(b"x")
+    h = WandBHandler(project="proj")
+    # Establish a high-water mark on this scope.
+    h.handle(make_event(kind="metric", payload={"loss": 1.0}, step=100))
+
+    artifact_event = SimpleNamespace(
+        kind="artifact",
+        scope="global",
+        payload={"path": str(artifact_file), "name": "a", "type": "misc"},
+        step=0,  # would be a regression for non-artifact events
+        extra={},
+    )
+    h.handle(artifact_event)
+
+    # mock.assert_called_once() raises with its own diagnostic on failure;
+    # this asserts the artifact was uploaded despite step < scope max.
+    mock_wandb.Artifact.assert_called_once()


### PR DESCRIPTION
## Summary
PR #165 unified the out-of-order step policy for `LocalStorageHandler` and `ConsoleHandler` via the shared `StepGuard` primitive, but `WandBHandler` was left out and relied on `wandb.run.log` silently dropping backward steps inside the SDK. That meant goggles would still build the `wandb.Image` / `wandb.Video` / `wandb.Plotly` payload, walk the full handler dispatch, and only have the upload rejected at the SDK boundary — with the warning surfaced (or not) by wandb's own format.

This PR wires `StepGuard` into `WandBHandler.handle()` with the same drop-with-warning policy as `LocalStorageHandler`:

- Out-of-order steps within a scope are dropped before any per-kind dispatch or wandb call.
- The warning goes through the goggles logger so the format matches the storage handler.
- `step is None` events bypass the check (no ordering contract).
- Artifact events bypass the check too — they are step-less and must always upload.

Follow-up to https://github.com/antonioterpin/goggles/pull/165#pullrequestreview-4196442792.

## Test plan
- [x] `tests/core/integrations/test_wandb.py` — 5 new tests covering backward-drop, equal/forward acceptance, per-scope isolation, `step=None` bypass, and the artifact bypass.
- [x] `uv run pytest tests/core/integrations/test_wandb.py` — 38 passed.
- [x] `uv run basedpyright goggles/_core/integrations/wandb.py tests/core/integrations/test_wandb.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
