### PR TITLE
test: add descriptive messages to every assert in tests/

### DIFF
--- a/tests/core/integrations/test_console.py
+++ b/tests/core/integrations/test_console.py
@@ -218,8 +218,7 @@ def test_to_from_dict_roundtrip(tmp_path):
 
 
 def test_handle_warns_on_backward_step_but_still_emits(handler):
-    """Console emits the message even when the step regresses, "
-    "with a warning."""
+    """Console still emits the message on a backward step, plus a warning."""
     e1 = DummyEvent(
         kind="log",
         payload="first",

--- a/tests/core/integrations/test_console.py
+++ b/tests/core/integrations/test_console.py
@@ -218,7 +218,8 @@ def test_to_from_dict_roundtrip(tmp_path):
 
 
 def test_handle_warns_on_backward_step_but_still_emits(handler):
-    """Console emits the message even when the step regresses, with a warning."""
+    """Console emits the message even when the step regresses, "
+    "with a warning."""
     e1 = DummyEvent(
         kind="log",
         payload="first",
@@ -246,7 +247,9 @@ def test_handle_warns_on_backward_step_but_still_emits(handler):
     finally:
         handler._logger.removeHandler(collector)
     output = " ".join(messages)
-    assert "first" in output
+    assert "first" in output, (
+        f"First payload should be in console output, got: {output!r}"
+    )
     assert "second-backward" in output, (
         "console handler must keep emitting even when step regresses"
     )
@@ -272,4 +275,7 @@ def test_handle_does_not_warn_when_step_is_none(handler):
         handler.handle(e)
     finally:
         handler._logger.removeHandler(collector)
-    assert not any("out-of-order" in m.lower() for m in messages)
+    assert not any("out-of-order" in m.lower() for m in messages), (
+        f"step=None should not trip the guard, "
+        f"but got out-of-order warnings: {messages!r}"
+    )

--- a/tests/core/integrations/test_logging_isolation.py
+++ b/tests/core/integrations/test_logging_isolation.py
@@ -10,7 +10,9 @@ def test_console_handler_isolation():
     handler = ConsoleHandler(name="test.console")
     handler.open()
     try:
-        assert handler._logger.propagate is False
+        assert handler._logger.propagate is False, (
+            "ConsoleHandler logger must not propagate to root"
+        )
     finally:
         handler.close()
 
@@ -24,7 +26,9 @@ def test_storage_handler_isolation(tmp_path: Path) -> None:
     handler = LocalStorageHandler(path=tmp_path, name="test.jsonl")
     handler.open()
     try:
-        assert handler._logger.propagate is False
+        assert handler._logger.propagate is False, (
+            "LocalStorageHandler logger must not propagate to root"
+        )
     finally:
         handler.close()
 
@@ -33,4 +37,6 @@ def test_wandb_handler_isolation():
     """Verify that WandBHandler logger has propagation disabled."""
     # WandBHandler sets propagate = False in __init__
     handler = WandBHandler()
-    assert handler._logger.propagate is False
+    assert handler._logger.propagate is False, (
+        "WandBHandler logger must not propagate to root"
+    )

--- a/tests/core/integrations/test_step_guard.py
+++ b/tests/core/integrations/test_step_guard.py
@@ -9,52 +9,73 @@ from goggles._core.integrations._step_guard import StepGuard
 
 def test_first_step_is_never_flagged():
     g = StepGuard()
-    assert g.check("global", 0) is False
-    assert g.check("train", 1000) is False  # different scope's first call
+    assert g.check("global", 0) is False, (
+        "First step in a scope must never be flagged as out-of-order"
+    )
+    assert g.check("train", 1000) is False, (
+        "First step in a different scope must never be flagged"
+    )
 
 
 def test_step_none_is_never_flagged():
     g = StepGuard()
     g.check("global", 10)
-    assert g.check("global", None) is False
+    assert g.check("global", None) is False, "step=None must never be flagged"
     # None must not affect the tracked max either
-    assert g.check("global", 11) is False
+    assert g.check("global", 11) is False, (
+        "step=11 after a None call should not be flagged (max should still be "
+        "10)"
+    )
 
 
 def test_strictly_backward_step_is_flagged():
     g = StepGuard()
     g.check("global", 10)
-    assert g.check("global", 5) is True
+    assert g.check("global", 5) is True, (
+        "step=5 after step=10 must be flagged as out-of-order"
+    )
 
 
 def test_equal_step_is_not_flagged():
     g = StepGuard()
     g.check("global", 10)
     # wandb allows multiple metrics at the same step (same call); mirror that.
-    assert g.check("global", 10) is False
+    assert g.check("global", 10) is False, (
+        "Equal step (10 after 10) must not be flagged "
+        "— mirrors wandb same-step semantics"
+    )
 
 
 def test_max_does_not_regress_after_flagged_step():
     g = StepGuard()
     g.check("global", 10)
     g.check("global", 5)  # flagged, must not lower the max
-    assert g.check("global", 6) is True  # still backward relative to 10
+    assert g.check("global", 6) is True, (
+        "step=6 must still be flagged (max should remain 10 after the flagged "
+        "step=5)"
+    )
 
 
 def test_per_scope_isolation():
     g = StepGuard()
     g.check("train", 10)
     # Different scope; lower step is fine.
-    assert g.check("eval", 1) is False
+    assert g.check("eval", 1) is False, (
+        "step=1 in 'eval' scope must not be flagged by 'train' scope's max"
+    )
     # train's max is unaffected.
-    assert g.check("train", 5) is True
+    assert g.check("train", 5) is True, (
+        "step=5 in 'train' scope must still be flagged (its max is 10)"
+    )
 
 
 def test_reset_clears_table():
     g = StepGuard()
     g.check("global", 10)
     g.reset()
-    assert g.check("global", 1) is False  # back to first-event semantics
+    assert g.check("global", 1) is False, (
+        "After reset(), the next call must be treated as the first step again"
+    )
 
 
 def test_concurrent_check_is_safe():
@@ -78,5 +99,11 @@ def test_concurrent_check_is_safe():
 
     # Whatever the scheduling, the max ends at 7 and a second call below
     # 7 must be flagged.
-    assert g.check("scope", 7) is False
-    assert g.check("scope", 0) is True
+    assert g.check("scope", 7) is False, (
+        "After 8 concurrent checks (steps 0..7), "
+        "step=7 must equal the max and not be flagged"
+    )
+    assert g.check("scope", 0) is True, (
+        "After 8 concurrent checks (max=7), "
+        "step=0 must be flagged as out-of-order"
+    )

--- a/tests/core/integrations/test_storage.py
+++ b/tests/core/integrations/test_storage.py
@@ -245,7 +245,10 @@ def test_save_trajectories_to_file_with_visualization(mock_save, tmp_handler):
     updated = tmp_handler._save_trajectories_to_file(event)
     npy_path = tmp_handler._base_path / updated["payload"]
     assert npy_path.exists(), "Trajectories .npy file should exist"
-    assert np.load(npy_path).shape == (3, 10, 2)
+    assert np.load(npy_path).shape == (3, 10, 2), (
+        f"Saved trajectories shape mismatch: expected (3, 10, 2), "
+        f"got {np.load(npy_path).shape}"
+    )
     mock_save.assert_called_once()
 
 
@@ -256,7 +259,9 @@ def test_save_trajectories_to_file_no_visualization(tmp_handler):
     }
     updated = tmp_handler._save_trajectories_to_file(event)
     npy_path = tmp_handler._base_path / updated["payload"]
-    assert npy_path.exists()
+    assert npy_path.exists(), (
+        f"Trajectories .npy file should exist at {npy_path}"
+    )
     viz_dir = tmp_handler._trajectories_dir / "visualizations"
     assert not viz_dir.exists() or not any(viz_dir.iterdir()), (
         "No visualization should be written when store_visualization is absent"
@@ -333,7 +338,9 @@ def test_handle_drops_backward_step_with_warning(tmp_handler):
     log_path = tmp_handler._base_path / "log.jsonl"
     lines = log_path.read_text().splitlines()
     assert len(lines) == 1, "second (backward-step) event must be dropped"
-    assert '"loss": 1.0' in lines[0]
+    assert '"loss": 1.0' in lines[0], (
+        f"First (in-order) event must remain on disk; got line: {lines[0]!r}"
+    )
     assert any(
         "out-of-order" in m.lower() and "step=5" in m for m in messages
     ), "Should warn that step=5 regressed"
@@ -345,7 +352,11 @@ def test_handle_allows_equal_and_forward_steps(tmp_handler):
     tmp_handler.handle(make_event("metric", {"b": 2}, step=3))  # equal — ok
     tmp_handler.handle(make_event("metric", {"c": 3}, step=4))  # forward — ok
     log_path = tmp_handler._base_path / "log.jsonl"
-    assert len(log_path.read_text().splitlines()) == 3
+    lines = log_path.read_text().splitlines()
+    assert len(lines) == 3, (
+        f"All three equal/forward-step events must be recorded, "
+        f"got {len(lines)} lines: {lines}"
+    )
 
 
 def test_handle_tracks_step_per_scope(tmp_handler):
@@ -354,7 +365,11 @@ def test_handle_tracks_step_per_scope(tmp_handler):
     # Lower step on a *different* scope must still be recorded.
     tmp_handler.handle(make_event("metric", {"x": 2}, scope="eval", step=1))
     log_path = tmp_handler._base_path / "log.jsonl"
-    assert len(log_path.read_text().splitlines()) == 2
+    lines = log_path.read_text().splitlines()
+    assert len(lines) == 2, (
+        f"Cross-scope events must both be recorded (step monotonicity is "
+        f"per-scope), got {len(lines)} lines: {lines}"
+    )
 
 
 def test_handle_records_events_without_step(tmp_handler):
@@ -362,4 +377,8 @@ def test_handle_records_events_without_step(tmp_handler):
     tmp_handler.handle(make_event("metric", {"a": 1}, step=10))
     tmp_handler.handle(make_event("log", {"msg": "no-step"}))  # step=None
     log_path = tmp_handler._base_path / "log.jsonl"
-    assert len(log_path.read_text().splitlines()) == 2
+    lines = log_path.read_text().splitlines()
+    assert len(lines) == 2, (
+        f"step=None events must always be recorded; "
+        f"expected 2 lines, got {len(lines)}: {lines}"
+    )

--- a/tests/core/integrations/test_wandb.py
+++ b/tests/core/integrations/test_wandb.py
@@ -225,9 +225,17 @@ def test_handle_trajectories_logs_plotly(mock_wandb, monkeypatch, dim):
     run = mock_wandb.init.return_value
     run.log.assert_called_once()
     logged_payload = run.log.call_args[0][0]
-    assert "trails" in logged_payload
-    assert logged_payload["tag"] == "viz"
-    assert run.log.call_args.kwargs["step"] == 2
+    assert "trails" in logged_payload, (
+        f"Logged trajectory payload should contain a 'trails' key, "
+        f"got keys: {list(logged_payload)}"
+    )
+    assert logged_payload["tag"] == "viz", (
+        f"Logged payload tag should be 'viz', got {logged_payload['tag']!r}"
+    )
+    assert run.log.call_args.kwargs["step"] == 2, (
+        f"wandb.log() should receive step=2, "
+        f"got step={run.log.call_args.kwargs.get('step')!r}"
+    )
 
 
 def test_handle_trajectories_bad_payload_warns(mock_wandb, monkeypatch):
@@ -248,7 +256,10 @@ def test_handle_trajectories_bad_payload_warns(mock_wandb, monkeypatch):
     finally:
         h._logger.removeHandler(collector)
 
-    assert any("trajectories" in m.lower() for m in messages)
+    assert any("trajectories" in m.lower() for m in messages), (
+        f"Should warn about bad trajectories payload, "
+        f"got messages: {messages!r}"
+    )
     mock_wandb.Plotly.assert_not_called()
 
 
@@ -296,7 +307,10 @@ def test_prepare_video_channels_first_preserved():
     F, C, H, W = 5, 3, 8, 12
     value = np.full((F, C, H, W), 128, dtype=np.uint8)
     out = h._prepare_video_for_wandb(value)
-    assert out.shape == (F, 3, H, W)
+    assert out.shape == (F, 3, H, W), (
+        f"Channels-first input must be preserved as (F, 3, H, W); "
+        f"expected ({F}, 3, {H}, {W}), got {out.shape}"
+    )
 
 
 @pytest.mark.parametrize("W", [1, 3, 4])
@@ -341,7 +355,10 @@ def test_prepare_video_5d_valid_channel_dim_passes(c):
     value = np.zeros((2, 4, c, 8, 12), dtype=np.uint8)
     out = h._prepare_video_for_wandb(value)
     expected_c = 3 if c == 1 else c
-    assert out.shape == (2, 4, expected_c, 8, 12)
+    assert out.shape == (2, 4, expected_c, 8, 12), (
+        f"5D input with C={c} "
+        f"should produce shape (2, 4, {expected_c}, 8, 12), got {out.shape}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -382,7 +399,10 @@ def test_prepare_video_channels_first_grayscale_repeated():
     F, H, W = 5, 8, 12
     value = np.full((F, 1, H, W), 128, dtype=np.uint8)
     out = h._prepare_video_for_wandb(value)
-    assert out.shape == (F, 3, H, W)
+    assert out.shape == (F, 3, H, W), (
+        f"Channels-first grayscale should be upcast to RGB; "
+        f"expected ({F}, 3, {H}, {W}), got {out.shape}"
+    )
 
 
 # -------------------------------------------------------------------------

--- a/tests/core/test_logger.py
+++ b/tests/core/test_logger.py
@@ -174,12 +174,21 @@ def test_push_promotes_image_shaped_ndarrays(
     img = np.zeros(shape, dtype=np.uint8)
     goggles_logger.push({"fig": img}, step=3)
     kinds = [c.args[0].kind for c in patch_bus.emit.call_args_list]
-    assert kinds == ["image"]
+    assert kinds == ["image"], (
+        f"Image-shaped ndarray should emit a single image event; "
+        f"got kinds={kinds}"
+    )
     event = patch_bus.emit.call_args_list[0].args[0]
     np.testing.assert_array_equal(event.payload, img)
-    assert event.extra["name"] == "fig"
-    assert event.extra["format"] == "png"
-    assert event.step == 3
+    assert event.extra["name"] == "fig", (
+        f"Image event extra['name'] should be 'fig', "
+        f"got {event.extra.get('name')!r}"
+    )
+    assert event.extra["format"] == "png", (
+        f"Image event extra['format'] should be 'png', "
+        f"got {event.extra.get('format')!r}"
+    )
+    assert event.step == 3, f"Image event step should be 3, got {event.step}"
 
 
 def test_push_keeps_1d_ndarray_as_metric(
@@ -194,7 +203,9 @@ def test_push_keeps_1d_ndarray_as_metric(
     vec = np.arange(4, dtype=np.float32)
     goggles_logger.push({"v": vec}, step=1)
     event = patch_bus.emit.call_args[0][0]
-    assert event.kind == "metric"
+    assert event.kind == "metric", (
+        f"1-D ndarray should stay as a metric, got kind={event.kind!r}"
+    )
     np.testing.assert_array_equal(event.payload["v"], vec)
 
 
@@ -214,17 +225,33 @@ def test_push_mixes_scalars_and_images(
     )
     events = [c.args[0] for c in patch_bus.emit.call_args_list]
     kinds = [e.kind for e in events]
-    assert kinds.count("metric") == 1
-    assert kinds.count("image") == 2
+    assert kinds.count("metric") == 1, (
+        f"Mixed dict should emit exactly one metric event, got kinds={kinds}"
+    )
+    assert kinds.count("image") == 2, (
+        f"Mixed dict with two images should emit two image events, "
+        f"got kinds={kinds}"
+    )
 
     metric_event = next(e for e in events if e.kind == "metric")
-    assert metric_event.payload == {"loss": 0.1, "acc": 0.9}
-    assert metric_event.step == 5
+    assert metric_event.payload == {"loss": 0.1, "acc": 0.9}, (
+        f"Metric event payload should contain only the scalars, "
+        f"got {metric_event.payload!r}"
+    )
+    assert metric_event.step == 5, (
+        f"Metric event step should be 5, got {metric_event.step}"
+    )
 
     image_names = [e.extra["name"] for e in events if e.kind == "image"]
-    assert sorted(image_names) == ["fig1", "fig2"]
+    assert sorted(image_names) == ["fig1", "fig2"], (
+        f"Image events should be named after their dict keys, "
+        f"got {sorted(image_names)}"
+    )
     for e in events:
-        assert e.step == 5
+        assert e.step == 5, (
+            f"Every event from a single push() must share the step; "
+            f"got step={e.step} for kind={e.kind!r}"
+        )
 
 
 def test_push_image_only_does_not_emit_empty_metric_event(
@@ -239,7 +266,10 @@ def test_push_image_only_does_not_emit_empty_metric_event(
     img = np.zeros((4, 4), dtype=np.uint8)
     goggles_logger.push({"fig": img}, step=2)
     kinds = [c.args[0].kind for c in patch_bus.emit.call_args_list]
-    assert "metric" not in kinds
+    assert "metric" not in kinds, (
+        f"Image-only push() must not emit an empty metric event; "
+        f"got kinds={kinds}"
+    )
 
 
 def test_push_forwards_extras_to_image_events(
@@ -254,8 +284,12 @@ def test_push_forwards_extras_to_image_events(
     img = np.zeros((4, 4), dtype=np.uint8)
     goggles_logger.push({"fig": img}, step=2, split="train")
     event = patch_bus.emit.call_args[0][0]
-    assert event.kind == "image"
-    assert event.extra["split"] == "train"
+    assert event.kind == "image", (
+        f"Promoted event should be an image event, got kind={event.kind!r}"
+    )
+    assert event.extra["split"] == "train", (
+        f"Image event should carry the 'split' extra, got extra={event.extra!r}"
+    )
 
 
 def test_scalar_emits_metric_event(
@@ -372,7 +406,10 @@ def test_default_level_emits_all_severities(
     """
     for method in ("debug", "info", "warning", "error", "critical"):
         getattr(text_logger, method)("x")
-    assert patch_bus.emit.call_count == 5
+    assert patch_bus.emit.call_count == 5, (
+        f"Default NOTSET gate should let all 5 severities through, "
+        f"got {patch_bus.emit.call_count}"
+    )
 
 
 def test_set_level_drops_below_threshold(patch_bus: MagicMock) -> None:
@@ -385,11 +422,17 @@ def test_set_level_drops_below_threshold(patch_bus: MagicMock) -> None:
     logger.set_level(logging.INFO)
 
     logger.debug("drop")
-    assert patch_bus.emit.call_count == 0
+    assert patch_bus.emit.call_count == 0, (
+        f"DEBUG must be dropped at level=INFO, got {patch_bus.emit.call_count} "
+        f"emit(s)"
+    )
 
     logger.info("keep")
     logger.warning("keep")
-    assert patch_bus.emit.call_count == 2
+    assert patch_bus.emit.call_count == 2, (
+        f"INFO + WARNING should both pass at level=INFO, "
+        f"got {patch_bus.emit.call_count} emit(s)"
+    )
 
 
 def test_set_level_warning_drops_info_and_debug(
@@ -405,12 +448,18 @@ def test_set_level_warning_drops_info_and_debug(
 
     logger.debug("drop")
     logger.info("drop")
-    assert patch_bus.emit.call_count == 0
+    assert patch_bus.emit.call_count == 0, (
+        f"DEBUG and INFO must be dropped at level=WARNING, "
+        f"got {patch_bus.emit.call_count} emit(s)"
+    )
 
     logger.warning("keep")
     logger.error("keep")
     logger.critical("keep")
-    assert patch_bus.emit.call_count == 3
+    assert patch_bus.emit.call_count == 3, (
+        f"WARNING, ERROR, CRITICAL should all pass at level=WARNING, "
+        f"got {patch_bus.emit.call_count} emit(s)"
+    )
 
 
 def test_level_via_constructor(patch_bus: MagicMock) -> None:
@@ -422,7 +471,10 @@ def test_level_via_constructor(patch_bus: MagicMock) -> None:
     logger = CoreTextLogger(name="t", scope="global", level=logging.WARNING)
     logger.info("drop")
     logger.warning("keep")
-    assert patch_bus.emit.call_count == 1
+    assert patch_bus.emit.call_count == 1, (
+        f"Constructor-time level=WARNING should drop INFO and keep WARNING, "
+        f"got {patch_bus.emit.call_count} emit(s)"
+    )
 
 
 def test_bind_preserves_level(patch_bus: MagicMock) -> None:
@@ -435,7 +487,10 @@ def test_bind_preserves_level(patch_bus: MagicMock) -> None:
     child = logger.bind(scope="run", k=1)
     child.info("drop")
     child.warning("keep")
-    assert patch_bus.emit.call_count == 1
+    assert patch_bus.emit.call_count == 1, (
+        "bind() must inherit parent's WARNING level "
+        f"(drop INFO, keep WARNING), got {patch_bus.emit.call_count} emit(s)"
+    )
 
 
 def test_set_level_is_logger_local(patch_bus: MagicMock) -> None:
@@ -451,7 +506,10 @@ def test_set_level_is_logger_local(patch_bus: MagicMock) -> None:
 
     quiet.debug("drop")
     loud.debug("keep")
-    assert patch_bus.emit.call_count == 1
+    assert patch_bus.emit.call_count == 1, (
+        f"set_level on 'quiet' must not affect 'loud'; "
+        f"expected 1 emit, got {patch_bus.emit.call_count}"
+    )
 
 
 def test_get_logger_level_kwarg(patch_bus: MagicMock) -> None:
@@ -465,4 +523,7 @@ def test_get_logger_level_kwarg(patch_bus: MagicMock) -> None:
     logger = gg.get_logger("x", level=logging.WARNING)
     logger.info("drop")
     logger.warning("keep")
-    assert patch_bus.emit.call_count == 1
+    assert patch_bus.emit.call_count == 1, (
+        f"get_logger(level=WARNING) should drop INFO and keep WARNING, "
+        f"got {patch_bus.emit.call_count} emit(s)"
+    )

--- a/tests/core/test_transport.py
+++ b/tests/core/test_transport.py
@@ -173,8 +173,10 @@ def _install_collector(
 
 def test_user_tag_is_portable() -> None:
     tag = _user_tag()
-    assert tag
-    assert isinstance(tag, str)
+    assert tag, f"_user_tag() should return a non-empty value, got {tag!r}"
+    assert isinstance(tag, str), (
+        f"_user_tag() should return a str, got {type(tag).__name__}"
+    )
 
 
 def test_default_socket_path_uses_tempdir_fallback(
@@ -183,8 +185,12 @@ def test_default_socket_path_uses_tempdir_fallback(
     monkeypatch.delenv("GOGGLES_SOCKET", raising=False)
     monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
     path = _default_socket_path()
-    assert path.endswith(".sock")
-    assert os.path.isabs(path)
+    assert path.endswith(".sock"), (
+        f"Default socket path should end with '.sock', got {path!r}"
+    )
+    assert os.path.isabs(path), (
+        f"Default socket path should be absolute, got {path!r}"
+    )
 
 
 def test_default_shm_threshold_env_parsing(
@@ -196,16 +202,30 @@ def test_default_shm_threshold_env_parsing(
         monkeypatch: pytest helper for environment isolation.
     """
     monkeypatch.delenv("GOGGLES_SHM_THRESHOLD", raising=False)
-    assert _default_shm_threshold() == _DEFAULT_SHM_THRESHOLD
+    assert _default_shm_threshold() == _DEFAULT_SHM_THRESHOLD, (
+        f"Without GOGGLES_SHM_THRESHOLD set, "
+        f"threshold should equal _DEFAULT_SHM_THRESHOLD "
+        f"({_DEFAULT_SHM_THRESHOLD}), got {_default_shm_threshold()}"
+    )
 
     monkeypatch.setenv("GOGGLES_SHM_THRESHOLD", "1234")
-    assert _default_shm_threshold() == 1234
+    assert _default_shm_threshold() == 1234, (
+        f"GOGGLES_SHM_THRESHOLD=1234 should yield 1234, "
+        f"got {_default_shm_threshold()}"
+    )
 
     monkeypatch.setenv("GOGGLES_SHM_THRESHOLD", "-1")
-    assert _default_shm_threshold() == 0
+    assert _default_shm_threshold() == 0, (
+        f"GOGGLES_SHM_THRESHOLD=-1 should clamp to 0, "
+        f"got {_default_shm_threshold()}"
+    )
 
     monkeypatch.setenv("GOGGLES_SHM_THRESHOLD", "not-an-int")
-    assert _default_shm_threshold() == _DEFAULT_SHM_THRESHOLD
+    assert _default_shm_threshold() == _DEFAULT_SHM_THRESHOLD, (
+        f"GOGGLES_SHM_THRESHOLD='not-an-int' should fall back to "
+        f"_DEFAULT_SHM_THRESHOLD ({_DEFAULT_SHM_THRESHOLD}), "
+        f"got {_default_shm_threshold()}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -223,10 +243,18 @@ def test_pack_unpack_small_roundtrip_scalar() -> None:
         step=7,
     )
     restored = _unpack_small(_frame_body(event))
-    assert restored.kind == "metric"
-    assert restored.payload == {"loss": 0.42}
-    assert restored.step == 7
-    assert restored.scope == "global"
+    assert restored.kind == "metric", (
+        f"Roundtripped event kind should be 'metric', got {restored.kind!r}"
+    )
+    assert restored.payload == {"loss": 0.42}, (
+        f"Roundtripped payload should equal original; got {restored.payload!r}"
+    )
+    assert restored.step == 7, (
+        f"Roundtripped step should be 7, got {restored.step!r}"
+    )
+    assert restored.scope == "global", (
+        f"Roundtripped scope should be 'global', got {restored.scope!r}"
+    )
 
 
 def test_pack_unpack_small_roundtrip_numpy() -> None:
@@ -239,8 +267,14 @@ def test_pack_unpack_small_roundtrip_numpy() -> None:
         lineno=2,
     )
     restored = _unpack_small(_frame_body(event))
-    assert isinstance(restored.payload, np.ndarray)
-    assert restored.payload.shape == (16, 16)
+    assert isinstance(restored.payload, np.ndarray), (
+        f"Roundtripped payload should be an ndarray, "
+        f"got {type(restored.payload).__name__}"
+    )
+    assert restored.payload.shape == (16, 16), (
+        f"Roundtripped ndarray should preserve shape (16, 16), "
+        f"got {restored.payload.shape}"
+    )
     np.testing.assert_array_equal(restored.payload, arr)
 
 
@@ -257,10 +291,18 @@ def test_pack_small_frame_header_layout() -> None:
         lineno=3,
     )
     frame = _pack_small_frame(event)
-    assert isinstance(frame, bytearray)
+    assert isinstance(frame, bytearray), (
+        f"_pack_small_frame should return a bytearray, "
+        f"got {type(frame).__name__}"
+    )
     kind, body_len = struct.unpack_from(_HEADER_FMT, frame, 0)
-    assert kind == _MSG_SMALL
-    assert body_len == len(frame) - _HEADER_SIZE
+    assert kind == _MSG_SMALL, (
+        f"Frame header kind should be _MSG_SMALL ({_MSG_SMALL}), got {kind}"
+    )
+    assert body_len == len(frame) - _HEADER_SIZE, (
+        f"Frame header body_len should equal frame size minus header; "
+        f"expected {len(frame) - _HEADER_SIZE}, got {body_len}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -273,7 +315,9 @@ def test_host_mode_emit_dispatches_to_handler(socket_path: str) -> None:
     transport = LocalTransport(socket_path=socket_path)
     try:
         assert transport.is_host, "first transport should become host"
-        assert transport.is_running
+        assert transport.is_running, (
+            "Newly-created host transport should report is_running=True"
+        )
         transport.attach(
             handlers=[_CollectingHandler().to_dict()], scopes=["global"]
         )
@@ -294,10 +338,15 @@ def test_host_mode_emit_dispatches_to_handler(socket_path: str) -> None:
         assert _wait_until(lambda: len(collector.events) == 1), (
             "host-mode emit should dispatch to attached handler"
         )
-        assert collector.events[0].payload == "hello"
+        assert collector.events[0].payload == "hello", (
+            f"Dispatched event payload should be 'hello', "
+            f"got {collector.events[0].payload!r}"
+        )
     finally:
         transport.shutdown(timeout=2.0)
-        assert not transport.is_running
+        assert not transport.is_running, (
+            "Transport should report is_running=False after shutdown"
+        )
         assert not Path(socket_path).exists(), (
             "host should clean up endpoint on shutdown"
         )
@@ -308,7 +357,9 @@ def test_shutdown_is_idempotent(socket_path: str) -> None:
     transport.shutdown(timeout=2.0)
     # A second shutdown must be a no-op, not raise.
     transport.shutdown(timeout=2.0)
-    assert not transport.is_running
+    assert not transport.is_running, (
+        "Transport must report is_running=False after a double shutdown"
+    )
 
 
 def test_host_emit_sync_dispatches_inline(socket_path: str) -> None:
@@ -326,8 +377,14 @@ def test_host_emit_sync_dispatches_inline(socket_path: str) -> None:
         )
         transport.emit_sync(event)
         # No wait needed: sync path must dispatch before returning.
-        assert len(collector.events) == 1
-        assert collector.events[0].payload == "sync"
+        assert len(collector.events) == 1, (
+            f"emit_sync should dispatch inline; "
+            f"expected 1 event, got {len(collector.events)}"
+        )
+        assert collector.events[0].payload == "sync", (
+            f"Dispatched event payload should be 'sync', "
+            f"got {collector.events[0].payload!r}"
+        )
     finally:
         transport.shutdown(timeout=2.0)
 
@@ -371,10 +428,18 @@ def test_empty_string_payloads_roundtrip_through_framing(
         event_kwargs["extra"] = extra
     event = Event(**event_kwargs)
     restored = _unpack_small(_frame_body(event))
-    assert restored.kind == kind
-    assert restored.payload == payload
+    assert restored.kind == kind, (
+        f"Roundtripped kind should be {kind!r}, got {restored.kind!r}"
+    )
+    assert restored.payload == payload, (
+        f"Roundtripped payload should equal original {payload!r}, "
+        f"got {restored.payload!r}"
+    )
     if extra is not None:
-        assert restored.extra == extra
+        assert restored.extra == extra, (
+            f"Roundtripped extra should equal original {extra!r}, "
+            f"got {restored.extra!r}"
+        )
 
 
 @pytest.mark.parametrize(
@@ -420,8 +485,13 @@ def test_empty_string_payloads_survive_host_emit_sync(
             event_kwargs["step"] = 0
             event_kwargs["extra"] = extra
         transport.emit_sync(Event(**event_kwargs))
-        assert len(collector.events) == 1
-        assert collector.events[0].payload == payload
+        assert len(collector.events) == 1, (
+            f"emit_sync should dispatch one event, got {len(collector.events)}"
+        )
+        assert collector.events[0].payload == payload, (
+            f"Dispatched payload should equal original {payload!r}, "
+            f"got {collector.events[0].payload!r}"
+        )
     finally:
         transport.shutdown(timeout=2.0)
 
@@ -512,7 +582,11 @@ def test_concurrent_attach_detach_with_emit(socket_path: str) -> None:
         stop.set()
         for t in threads:
             t.join(timeout=2.0)
-            assert not t.is_alive()
+            assert not t.is_alive(), (
+                f"Thread {t.name!r} "
+                f"did not exit within 2s — bus likely deadlocked under "
+                f"concurrent attach/emit"
+            )
     finally:
         transport.shutdown(timeout=2.0)
 
@@ -525,7 +599,9 @@ def test_concurrent_attach_detach_with_emit(socket_path: str) -> None:
 def test_second_transport_connects_as_client(socket_path: str) -> None:
     host = LocalTransport(socket_path=socket_path)
     try:
-        assert host.is_host
+        assert host.is_host, (
+            "First transport on a fresh socket must become host"
+        )
         client = LocalTransport(socket_path=socket_path)
         try:
             assert not client.is_host, (
@@ -547,7 +623,10 @@ def test_second_transport_connects_as_client(socket_path: str) -> None:
             assert _wait_until(lambda: len(collector.events) == 1), (
                 "host should receive event from connected client"
             )
-            assert collector.events[0].payload == "from-client"
+            assert collector.events[0].payload == "from-client", (
+                f"Host should receive the client's payload 'from-client', "
+                f"got {collector.events[0].payload!r}"
+            )
         finally:
             client.shutdown(timeout=2.0)
     finally:
@@ -574,9 +653,14 @@ def test_client_numpy_payload_roundtrip(socket_path: str) -> None:
                 )
             )
 
-            assert _wait_until(lambda: len(collector.events) == 1)
+            assert _wait_until(lambda: len(collector.events) == 1), (
+                "Host should receive the client's image event within timeout"
+            )
             got = collector.events[0].payload
-            assert isinstance(got, np.ndarray)
+            assert isinstance(got, np.ndarray), (
+                f"Roundtripped payload should be an ndarray, "
+                f"got {type(got).__name__}"
+            )
             np.testing.assert_array_equal(got, arr)
         finally:
             client.shutdown(timeout=2.0)
@@ -634,7 +718,10 @@ def test_client_numpy_payload_is_snapshotted_before_mutation(
                 f"{path_label} client event should be delivered"
             )
             got = collector.events[0].payload
-            assert isinstance(got, np.ndarray)
+            assert isinstance(got, np.ndarray), (
+                f"{path_label}: roundtripped payload should be an ndarray, "
+                f"got {type(got).__name__}"
+            )
             np.testing.assert_array_equal(got, expected)
         finally:
             client.shutdown(timeout=2.0)
@@ -651,7 +738,10 @@ def test_shm_side_channel_for_large_payload(socket_path: str) -> None:
             _install_collector(host, collector)
 
             arr = np.arange(64 * 64, dtype=np.float32).reshape(64, 64)
-            assert arr.nbytes > 1024
+            assert arr.nbytes > 1024, (
+                f"Test setup expects arr above the 1024-byte shm threshold; "
+                f"got {arr.nbytes} bytes"
+            )
             client.emit(
                 Event(
                     kind="image",
@@ -662,16 +752,31 @@ def test_shm_side_channel_for_large_payload(socket_path: str) -> None:
                 )
             )
 
-            assert _wait_until(lambda: len(collector.events) == 1)
+            assert _wait_until(lambda: len(collector.events) == 1), (
+                "Host should receive the large-payload event via shm side "
+                "channel"
+            )
             got = collector.events[0].payload
-            assert isinstance(got, np.ndarray)
-            assert got.shape == arr.shape
-            assert got.dtype == arr.dtype
+            assert isinstance(got, np.ndarray), (
+                f"Roundtripped payload should be an ndarray, "
+                f"got {type(got).__name__}"
+            )
+            assert got.shape == arr.shape, (
+                f"Roundtripped ndarray shape mismatch: expected {arr.shape}, "
+                f"got {got.shape}"
+            )
+            assert got.dtype == arr.dtype, (
+                f"Roundtripped ndarray dtype mismatch: expected {arr.dtype}, "
+                f"got {got.dtype}"
+            )
             np.testing.assert_array_equal(got, arr)
             # Client must have released its pending-shm tracking.
             assert _wait_until(
                 lambda: not client._pending_shm,  # type: ignore[attr-defined]
                 timeout=1.0,
+            ), (
+                "Client must release pending-shm tracking after the host "
+                "consumes the buffer"
             )
         finally:
             client.shutdown(timeout=2.0)
@@ -715,9 +820,15 @@ def test_shm_threshold_zero_disables_side_channel(
                 )
             )
 
-            assert _wait_until(lambda: len(collector.events) == 1)
+            assert _wait_until(lambda: len(collector.events) == 1), (
+                "shm_threshold=0 should still deliver the event via the SMALL "
+                "frame path"
+            )
             got = collector.events[0].payload
-            assert isinstance(got, np.ndarray)
+            assert isinstance(got, np.ndarray), (
+                f"Roundtripped payload should be an ndarray, "
+                f"got {type(got).__name__}"
+            )
             np.testing.assert_array_equal(got, arr)
         finally:
             client.shutdown(timeout=2.0)
@@ -736,7 +847,10 @@ def test_client_attach_and_detach_control_frames(socket_path: str) -> None:
     try:
         client = LocalTransport(socket_path=socket_path)
         try:
-            assert not client.is_host
+            assert not client.is_host, (
+                "Second transport on the same socket must connect as client, "
+                "not host"
+            )
             bus = host._bus  # type: ignore[attr-defined]
             client.attach(
                 handlers=[_CollectingHandler().to_dict()],
@@ -759,8 +873,14 @@ def test_client_attach_and_detach_control_frames(socket_path: str) -> None:
                     lineno=1,
                 )
             )
-            assert _wait_until(lambda: len(collector.events) == 1)
-            assert collector.events[0].payload == "before-detach"
+            assert _wait_until(lambda: len(collector.events) == 1), (
+                "Host should receive 'before-detach' event before client "
+                "detaches"
+            )
+            assert collector.events[0].payload == "before-detach", (
+                f"First event payload should be 'before-detach', "
+                f"got {collector.events[0].payload!r}"
+            )
 
             client.detach("collector", "global")
             assert _wait_until(lambda: "collector" not in bus.handlers), (
@@ -779,7 +899,7 @@ def test_client_attach_and_detach_control_frames(socket_path: str) -> None:
             assert not _wait_until(
                 lambda: len(collector.events) > 1,
                 timeout=0.2,
-            )
+            ), "Detached collector must not receive any further events"
         finally:
             client.shutdown(timeout=2.0)
     finally:
@@ -858,7 +978,10 @@ def test_shutdown_flushes_shm_frames(socket_path: str) -> None:
                 lambda: len(collector.events) == n, timeout=5.0
             ), f"host got {len(collector.events)}/{n}"
             # No leaked shm references on the client side.
-            assert not client._pending_shm  # type: ignore[attr-defined]
+            assert not client._pending_shm, (  # type: ignore[attr-defined]
+                "Client should have no pending shm refs after flush; "
+                f"got {client._pending_shm}"  # type: ignore[attr-defined]
+            )
         finally:
             pass
     finally:
@@ -931,7 +1054,9 @@ def test_unix_socket_is_owner_only(socket_path: str) -> None:
     """
     transport = LocalTransport(socket_path=socket_path)
     try:
-        assert transport.is_host
+        assert transport.is_host, (
+            "Newly-created transport on a fresh socket must become host"
+        )
         mode = os.stat(socket_path).st_mode & 0o777
         # Under a restrictive umask we expect exactly 0o600; tolerate
         # environments that narrow it further (0o600 or less-permissive).
@@ -1146,7 +1271,10 @@ def test_two_independent_processes_share_host(
     with _host_subprocess(socket_path, tmp_path, expected=1) as (_, out_path):
         client = LocalTransport(socket_path=socket_path)
         try:
-            assert not client.is_host
+            assert not client.is_host, (
+                "Client transport must connect to the host subprocess, "
+                "not rebind"
+            )
             client.emit(
                 Event(
                     kind="log",
@@ -1179,7 +1307,10 @@ def test_cross_process_no_loss_at_bulk_send(
     with _host_subprocess(socket_path, tmp_path, expected=n) as (_, out_path):
         client = LocalTransport(socket_path=socket_path)
         try:
-            assert not client.is_host
+            assert not client.is_host, (
+                "Client transport must connect to the host subprocess, "
+                "not rebind"
+            )
             for i in range(n):
                 client.emit(
                     Event(
@@ -1224,7 +1355,10 @@ def test_cross_process_multiple_concurrent_clients(
         c2 = LocalTransport(socket_path=socket_path)
         try:
             for c in (c1, c2):
-                assert not c.is_host
+                assert not c.is_host, (
+                    "Both client transports must connect to the host "
+                    "subprocess, not rebind"
+                )
 
             def emit_many(client: LocalTransport, tag: str) -> None:
                 for i in range(n_per_client):
@@ -1479,9 +1613,13 @@ def test_try_unlink_shm_tolerates_missing_name() -> None:
 def test_next_shm_name_is_unique_and_prefixed() -> None:
     a = _next_shm_name()
     b = _next_shm_name()
-    assert a.startswith(_SHM_NAME_PREFIX)
-    assert b.startswith(_SHM_NAME_PREFIX)
-    assert a != b
+    assert a.startswith(_SHM_NAME_PREFIX), (
+        f"shm name {a!r} should start with prefix {_SHM_NAME_PREFIX!r}"
+    )
+    assert b.startswith(_SHM_NAME_PREFIX), (
+        f"shm name {b!r} should start with prefix {_SHM_NAME_PREFIX!r}"
+    )
+    assert a != b, f"_next_shm_name() must return unique names, got {a!r} twice"
 
 
 def test_pack_unpack_large_roundtrip_and_unlinks_shm() -> None:
@@ -1509,14 +1647,38 @@ def test_pack_unpack_large_roundtrip_and_unlinks_shm() -> None:
 
         restored = _unpack_large(_pack_large(event, shm_name))
 
-        assert restored.kind == event.kind
-        assert restored.scope == event.scope
-        assert restored.filepath == event.filepath
-        assert restored.lineno == event.lineno
-        assert restored.step == event.step
-        assert restored.time == event.time
-        assert restored.extra == event.extra
-        assert isinstance(restored.payload, np.ndarray)
+        assert restored.kind == event.kind, (
+            f"LARGE-frame roundtrip kind mismatch: expected {event.kind!r}, "
+            f"got {restored.kind!r}"
+        )
+        assert restored.scope == event.scope, (
+            f"LARGE-frame roundtrip scope mismatch: expected {event.scope!r}, "
+            f"got {restored.scope!r}"
+        )
+        assert restored.filepath == event.filepath, (
+            f"LARGE-frame roundtrip filepath mismatch: expected "
+            f"{event.filepath!r}, got {restored.filepath!r}"
+        )
+        assert restored.lineno == event.lineno, (
+            f"LARGE-frame roundtrip lineno mismatch: expected "
+            f"{event.lineno!r}, got {restored.lineno!r}"
+        )
+        assert restored.step == event.step, (
+            f"LARGE-frame roundtrip step mismatch: expected {event.step!r}, "
+            f"got {restored.step!r}"
+        )
+        assert restored.time == event.time, (
+            f"LARGE-frame roundtrip time mismatch: expected {event.time!r}, "
+            f"got {restored.time!r}"
+        )
+        assert restored.extra == event.extra, (
+            f"LARGE-frame roundtrip extra mismatch: expected {event.extra!r}, "
+            f"got {restored.extra!r}"
+        )
+        assert isinstance(restored.payload, np.ndarray), (
+            f"LARGE-frame restored payload should be an ndarray, "
+            f"got {type(restored.payload).__name__}"
+        )
         np.testing.assert_array_equal(restored.payload, arr)
         with pytest.raises(FileNotFoundError):
             shared_memory.SharedMemory(name=shm_name)
@@ -1552,7 +1714,10 @@ def test_reap_orphan_shm_removes_only_old_goggles_segments(
         os.utime(stale_path, (old, old))
 
         reaped = _reap_orphan_shm(max_age_s=600.0)
-        assert reaped >= 1
+        assert reaped >= 1, (
+            f"_reap_orphan_shm should reap at least the stale segment, "
+            f"got reaped={reaped}"
+        )
         assert not stale_path.exists(), "stale segment must be unlinked"
         assert (Path("/dev/shm") / fresh.name).exists(), (
             "fresh segment must not be touched"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -155,8 +155,12 @@ def test_private_fields_cannot_be_overridden_by_from_config() -> None:
             }
         )
     msg = str(exc_info.value)
-    assert "Private fields cannot be overridden" in msg
-    assert "_secret" in msg
+    assert "Private fields cannot be overridden" in msg, (
+        f"Error message should explain the rule, got {msg!r}"
+    )
+    assert "_secret" in msg, (
+        f"Error message should name the offending field '_secret', got {msg!r}"
+    )
 
 
 def test_undeclared_private_keys_are_silently_ignored() -> None:
@@ -164,9 +168,16 @@ def test_undeclared_private_keys_are_silently_ignored() -> None:
     cfg = DummyTypedConfig.from_config(
         {"_not_declared": 1, "name": "x", "port": "y"}
     )
-    assert cfg.name == "x"
-    assert cfg.port == "y"
-    assert not hasattr(cfg, "_not_declared")
+    assert cfg.name == "x", (
+        f"Declared 'name' should be set to 'x', got {cfg.name!r}"
+    )
+    assert cfg.port == "y", (
+        f"Declared 'port' should be set to 'y', got {cfg.port!r}"
+    )
+    assert not hasattr(cfg, "_not_declared"), (
+        "Undeclared private key '_not_declared' must not be attached to the "
+        "config"
+    )
 
 
 def test_private_fields_not_serialized_yaml_json_roundtrip(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -224,9 +224,16 @@ def test_averagefilter_name() -> None:
 )
 def test_windowbuffer_filter_init_state(factory: Any) -> None:
     f = factory()
-    assert f.buffer is None
-    assert f.n_seen == 0
-    assert f.index == 0
+    assert f.buffer is None, (
+        f"Filter should start with buffer=None before any update; "
+        f"got {f.buffer!r}"
+    )
+    assert f.n_seen == 0, (
+        f"Filter should start with n_seen=0 before any update; got {f.n_seen}"
+    )
+    assert f.index == 0, (
+        f"Filter should start with index=0 before any update; got {f.index}"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -15,7 +15,11 @@ def _parse(text: str) -> object:
 
 def test_yaml_dump_roundtrips_plain_mapping() -> None:
     payload = {"name": "cfg", "values": [1, 2, 3], "nested": {"a": 1}}
-    assert _parse(yaml_dump(payload)) == payload
+    parsed = _parse(yaml_dump(payload))
+    assert parsed == payload, (
+        f"Plain mapping should roundtrip via yaml_dump; "
+        f"expected {payload!r}, got {parsed!r}"
+    )
 
 
 def test_yaml_dump_normalizes_numpy_arrays_and_scalars() -> None:
@@ -27,8 +31,7 @@ def test_yaml_dump_normalizes_numpy_arrays_and_scalars() -> None:
         "bool_scalar": np.bool_(True),
         "zero_dim": np.array(7),
     }
-    loaded = _parse(yaml_dump(payload))
-    assert loaded == {
+    expected = {
         "array_1d": [1, 2, 3],
         "array_2d": [[1.0, 2.0], [3.0, 4.0]],
         "int_scalar": 42,
@@ -36,6 +39,11 @@ def test_yaml_dump_normalizes_numpy_arrays_and_scalars() -> None:
         "bool_scalar": True,
         "zero_dim": 7,
     }
+    loaded = _parse(yaml_dump(payload))
+    assert loaded == expected, (
+        f"yaml_dump should normalize numpy arrays/scalars to native Python; "
+        f"expected {expected!r}, got {loaded!r}"
+    )
 
 
 def test_yaml_dump_handles_nested_numpy_in_lists_and_dicts() -> None:
@@ -43,24 +51,50 @@ def test_yaml_dump_handles_nested_numpy_in_lists_and_dicts() -> None:
         "xs": [np.float32(1.5), np.int16(2), np.array([3, 4])],
         "ys": {"a": np.bool_(False), "b": [np.array([[1], [2]])]},
     }
-    loaded = _parse(yaml_dump(payload))
-    assert loaded == {
+    expected = {
         "xs": [1.5, 2, [3, 4]],
         "ys": {"a": False, "b": [[[1], [2]]]},
     }
+    loaded = _parse(yaml_dump(payload))
+    assert loaded == expected, (
+        f"yaml_dump should normalize numpy values nested in lists/dicts; "
+        f"expected {expected!r}, got {loaded!r}"
+    )
 
 
 def test_yaml_dump_accepts_top_level_numpy_values() -> None:
-    assert _parse(yaml_dump(np.array([1, 2, 3], dtype=np.int32))) == [1, 2, 3]
-    assert _parse(yaml_dump(np.float32(1.5))) == 1.5
-    assert _parse(yaml_dump(np.int64(7))) == 7
+    arr_loaded = _parse(yaml_dump(np.array([1, 2, 3], dtype=np.int32)))
+    assert arr_loaded == [1, 2, 3], (
+        f"Top-level int32 ndarray should normalize to a list; "
+        f"got {arr_loaded!r}"
+    )
+    f32_loaded = _parse(yaml_dump(np.float32(1.5)))
+    assert f32_loaded == 1.5, (
+        f"Top-level np.float32 should normalize to a Python float; "
+        f"got {f32_loaded!r}"
+    )
+    i64_loaded = _parse(yaml_dump(np.int64(7)))
+    assert i64_loaded == 7, (
+        f"Top-level np.int64 should normalize to a Python int; "
+        f"got {i64_loaded!r}"
+    )
 
 
 def test_yaml_dump_normalizes_numpy_scalar_keys() -> None:
     payload = {np.int64(1): "one", np.float32(2.0): "two"}
-    assert _parse(yaml_dump(payload)) == {1: "one", 2.0: "two"}
+    parsed = _parse(yaml_dump(payload))
+    expected = {1: "one", 2.0: "two"}
+    assert parsed == expected, (
+        f"yaml_dump should normalize numpy scalar keys to native Python; "
+        f"expected {expected!r}, got {parsed!r}"
+    )
 
 
 def test_yaml_dump_normalizes_object_array_elements() -> None:
     payload = np.array([np.int64(1), np.float32(2.5), "s"], dtype=object)
-    assert _parse(yaml_dump(payload)) == [1, 2.5, "s"]
+    parsed = _parse(yaml_dump(payload))
+    expected = [1, 2.5, "s"]
+    assert parsed == expected, (
+        f"yaml_dump should normalize numpy elements inside object arrays; "
+        f"expected {expected!r}, got {parsed!r}"
+    )


### PR DESCRIPTION
## Summary

- Sweeps `tests/` so every `assert` carries an explanatory message that names what was expected vs. observed (per `docs/standards/testing.md`).
- 132 bare asserts were rewritten across 10 test files; the suite now has 201 asserts, all with messages.
- No production code changed; full pytest suite (604 tests, 3 skipped, 2 deselected) still passes.

Closes #171.

## Test plan

- [x] `python -c 'import ast, pathlib; ...'` confirms zero `ast.Assert` nodes with `msg=None` under `tests/`.
- [x] `uv run pytest -m "not resilience"` — 604 passed, 3 skipped.
- [x] `uv run pre-commit run` on changed files — ruff and ruff-format pass; pre-existing pydoclint warnings on `test_wandb.py` / `test_console.py` are unchanged (28 before, 28 after — none introduced by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)