### PR TITLE
fix: batch same-step W&B commits to fix unreliable display (#177)

### DIFF
--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -283,6 +283,15 @@ class WandBHandler:
         self._wandb_run: Run | None = None
         self._current_scope: str | None = None
         self._step_guard = StepGuard()
+        # Pending writes batched per scope, keyed by step. The W&B cloud
+        # backend treats multiple ``run.log({...}, step=N)`` calls at the
+        # same N as best-effort merges (a panel can register one key but
+        # show "No data available" for sibling keys logged at the same
+        # step — see issue #177). Coalesce same-step events into a single
+        # commit; a step change or ``close()`` flushes the buffer.
+        # ``step is None`` events bypass the buffer to preserve W&B's
+        # auto-increment semantics.
+        self._pending: dict[str, dict[str, Any]] = {}
 
     def can_handle(self, kind: str) -> bool:
         """Return True if the handler supports this event kind.
@@ -362,7 +371,7 @@ class WandBHandler:
             return
         for k, v in extra.items():
             payload[k] = v
-        run.log(payload, step=step)
+        self._stage(run, scope, step, payload)
 
     def _handle_media(
         self,
@@ -397,7 +406,7 @@ class WandBHandler:
         for k, v in extra.items():
             logs[k] = v
         if logs:
-            run.log(logs, step=step)
+            self._stage(run, scope, step, logs)
 
     def _build_wandb_video(
         self, name: str, value: Any, extra: Mapping[str, Any]
@@ -478,7 +487,7 @@ class WandBHandler:
         for k, v in extra.items():
             logs[k] = v
         if logs:
-            run.log(logs, step=step)
+            self._stage(run, scope, step, logs)
 
     def _handle_vector_field(
         self,
@@ -530,7 +539,7 @@ class WandBHandler:
         for k, v in extra.items():
             logs[k] = v
         if logs:
-            run.log(logs, step=step)
+            self._stage(run, scope, step, logs)
 
     def _handle_trajectories(
         self,
@@ -567,10 +576,12 @@ class WandBHandler:
         for k, v in extra.items():
             logs[k] = v
         if logs:
-            run.log(logs, step=step)
+            self._stage(run, scope, step, logs)
 
     def close(self) -> None:
         """Finish all active W&B runs."""
+        for scope in list(self._pending.keys()):
+            self._flush_pending(scope)
         for run in list(self._runs.values()):
             if run is not None:
                 try:
@@ -578,6 +589,7 @@ class WandBHandler:
                 except Exception as exc:
                     self._logger.warning("Failed to finish W&B run: %s", exc)
         self._runs.clear()
+        self._pending.clear()
         self._wandb_run = None
         self._current_scope = None
 
@@ -619,6 +631,57 @@ class WandBHandler:
             group=serialized.get("group"),
             tags=serialized.get("tags"),
         )
+
+    def _stage(
+        self,
+        run: Run,
+        scope: str,
+        step: int | None,
+        logs: Mapping[str, Any],
+    ) -> None:
+        """Buffer a log payload for ``scope`` at ``step``.
+
+        Same-step events are merged into a single ``run.log`` commit; a
+        step change flushes the previous buffer first. ``step is None``
+        bypasses the buffer entirely so W&B's auto-increment semantics
+        are preserved for callers that don't pin a step.
+
+        Args:
+            run: The W&B run for ``scope`` (already created).
+            scope: The scope being logged under.
+            step: User-supplied step, or None for auto-increment.
+            logs: Mapping of keys to values to merge into the commit.
+        """
+        if step is None:
+            self._flush_pending(scope)
+            run.log(dict(logs))
+            return
+        pending = self._pending.get(scope)
+        if pending is None:
+            pending = {"step": step, "logs": {}}
+            self._pending[scope] = pending
+        elif pending["step"] != step:
+            self._flush_pending(scope)
+            pending = self._pending.setdefault(
+                scope, {"step": step, "logs": {}}
+            )
+            pending["step"] = step
+        pending["logs"].update(logs)
+
+    def _flush_pending(self, scope: str) -> None:
+        """Commit any pending logs for ``scope`` in one ``run.log`` call.
+
+        Args:
+            scope: The scope whose pending buffer should be flushed.
+        """
+        pending = self._pending.get(scope)
+        if not pending or not pending["logs"]:
+            return
+        run = self._runs.get(scope)
+        if run is not None:
+            run.log(pending["logs"], step=pending["step"])
+        pending["logs"] = {}
+        pending["step"] = None
 
     def _get_or_create_run(self, scope: str, extra_config: dict) -> Run:
         """Get or create a W&B run for the given scope.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ pythonpath = ["goggles"]
 markers = [
         "resilience: marks tests as resilience tests (slow, disruptive)",
         "xdist_group: ensures tests run in the same group (serial execution within group)",
+        "slow: marks tests that exercise external integrations (e.g. wandb offline mode)",
 ]
 filterwarnings = [
         "error",

--- a/tests/core/integrations/test_wandb.py
+++ b/tests/core/integrations/test_wandb.py
@@ -1,9 +1,14 @@
+import glob
 import logging
+import os
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+from wandb.proto import wandb_internal_pb2 as pb
+from wandb.sdk.internal.datastore import DataStore
 
 import goggles._core.integrations.wandb as wandb_module
 from goggles._core.integrations.wandb import WandBHandler
@@ -253,6 +258,8 @@ def test_handle_vector_field_logs_image(mock_wandb, monkeypatch):
     )
 
     h.handle(event)
+    # Same-step events are buffered until a step change or close(); flush.
+    h.close()
 
     run = mock_wandb.init.return_value
     render_mock.assert_called_once_with(
@@ -293,6 +300,8 @@ def test_handle_trajectories_logs_plotly(mock_wandb, monkeypatch, dim):
     )
 
     h.handle(event)
+    # Same-step events are buffered until a step change or close(); flush.
+    h.close()
 
     render_mock.assert_called_once()
     np.testing.assert_array_equal(render_mock.call_args[0][0], payload)
@@ -475,6 +484,8 @@ def test_handle_drops_backward_step_with_warning(mock_wandb):
     try:
         h.handle(e1)
         h.handle(e2)
+        # Flush the pending step=10 buffer to assert against its single commit.
+        h.close()
     finally:
         h._logger.removeHandler(collector)
 
@@ -492,15 +503,32 @@ def test_handle_drops_backward_step_with_warning(mock_wandb):
 
 
 def test_handle_allows_equal_and_forward_steps(mock_wandb):
-    """Equal and forward steps within the same scope are forwarded to wandb."""
+    """Same-step events coalesce into one commit; step changes flush.
+
+    Logging at step 3, 3, 4 and then closing yields exactly two commits:
+    one merged ``{a, b}`` row at step=3 and one ``{c}`` row at step=4.
+    Coalescing same-step writes into a single ``run.log`` is the fix for
+    issue #177 (W&B not displaying logged data on same-step keys).
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
     h = WandBHandler(project="proj")
     h.handle(make_event(kind="metric", payload={"a": 1}, step=3))
     h.handle(make_event(kind="metric", payload={"b": 2}, step=3))  # equal
     h.handle(make_event(kind="metric", payload={"c": 3}, step=4))  # forward
+    h.close()  # flush pending step=4
 
     run = mock_wandb.init.return_value
-    assert run.log.call_count == 3, (
-        f"Expected 3 wandb.log calls; saw {run.log.call_count}"
+    assert run.log.call_count == 2, (
+        f"Expected 2 wandb.log calls (one per step); saw {run.log.call_count}"
+    )
+    calls = [(c.args[0], c.kwargs.get("step")) for c in run.log.call_args_list]
+    assert calls[0] == ({"a": 1, "b": 2}, 3), (
+        f"step=3 commit should batch keys 'a' and 'b'; got {calls[0]}"
+    )
+    assert calls[1] == ({"c": 3}, 4), (
+        f"step=4 commit should carry only 'c'; got {calls[1]}"
     )
 
 
@@ -512,6 +540,7 @@ def test_handle_tracks_step_per_scope(mock_wandb):
     )
     # Lower step on a different scope must still be forwarded.
     h.handle(make_event(kind="metric", payload={"x": 2}, scope="eval", step=1))
+    h.close()  # flush both per-scope buffers
 
     # mock_wandb.init returns the same MagicMock for every scope, so both
     # scopes share the same .log mock; assert on total calls instead.
@@ -555,3 +584,207 @@ def test_handle_artifact_bypasses_step_guard(mock_wandb, tmp_path):
     # mock.assert_called_once() raises with its own diagnostic on failure;
     # this asserts the artifact was uploaded despite step < scope max.
     mock_wandb.Artifact.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #177 — W&B not displaying logged data.
+#
+# Same-step ``run.log`` calls were unreliable on the W&B cloud backend: a
+# panel could register one key but show "No data available" for sibling
+# keys logged at the same step. The fix coalesces same-step events into a
+# single commit per (scope, step).
+# ---------------------------------------------------------------------------
+
+
+def test_same_step_events_batch_into_single_log_call(
+    mock_wandb: MagicMock,
+) -> None:
+    """Three events at step=100 produce one ``run.log`` once step changes.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    h = WandBHandler(project="p")
+    img1 = np.zeros((4, 4, 3), dtype=np.uint8)
+    img2 = np.zeros((4, 4, 4), dtype=np.uint8)
+    h.handle(
+        SimpleNamespace(
+            kind="image",
+            scope="global",
+            payload=img1,
+            step=100,
+            extra={"name": "RGB"},
+        )
+    )
+    h.handle(
+        SimpleNamespace(
+            kind="image",
+            scope="global",
+            payload=img2,
+            step=100,
+            extra={"name": "RGBA"},
+        )
+    )
+    h.handle(make_event(kind="metric", payload={"acc": 0.9}, step=100))
+
+    run = mock_wandb.init.return_value
+    run.log.assert_not_called()  # all three are buffered at step=100
+
+    # Step change forces a single batched commit for the previous step.
+    h.handle(make_event(kind="metric", payload={"acc": 0.95}, step=101))
+    assert run.log.call_count == 1, (
+        "Same-step events must batch into ONE run.log call"
+    )
+    logged, kwargs = run.log.call_args.args[0], run.log.call_args.kwargs
+    assert kwargs["step"] == 100
+    got = sorted(logged)
+    assert set(logged.keys()) == {"RGB", "RGBA", "acc"}, (
+        f"All same-step keys must land in the single commit; got {got}"
+    )
+
+
+def test_close_flushes_pending_buffer(mock_wandb: MagicMock) -> None:
+    """``close()`` flushes the pending step before finishing the run.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    h = WandBHandler(project="p")
+    h.handle(make_event(kind="metric", payload={"loss": 0.1}, step=42))
+    run = mock_wandb.init.return_value
+    run.log.assert_not_called()  # buffered, not yet committed
+
+    h.close()
+    run.log.assert_called_once_with({"loss": 0.1}, step=42)
+    run.finish.assert_called()
+
+
+def test_step_none_bypasses_buffer_to_preserve_autoincrement(
+    mock_wandb: MagicMock,
+) -> None:
+    """``step=None`` flushes any pending buffer and commits immediately.
+
+    Wandb auto-increments the internal step for step-less ``run.log`` calls,
+    so callers relying on auto-increment must not see those events
+    coalesced into a single row.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    h = WandBHandler(project="p")
+    h.handle(make_event(kind="metric", payload={"a": 1}, step=5))
+    h.handle(make_event(kind="metric", payload={"b": 2}, step=None))
+    h.handle(make_event(kind="metric", payload={"c": 3}, step=None))
+
+    run = mock_wandb.init.return_value
+    # 1 flush of step=5 + 2 immediate step-less commits == 3 calls.
+    assert run.log.call_count == 3
+    seen = [(c.args[0], c.kwargs.get("step")) for c in run.log.call_args_list]
+    assert seen[0] == ({"a": 1}, 5)
+    assert (
+        seen[1][0] == {"b": 2}
+        and "step" not in run.log.call_args_list[1].kwargs
+    )
+    assert (
+        seen[2][0] == {"c": 3}
+        and "step" not in run.log.call_args_list[2].kwargs
+    )
+
+
+@pytest.mark.slow
+def test_example_04_logs_all_keys_at_step_100_offline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end smoke against the real wandb client (offline mode).
+
+    Drives the same flow as ``examples/04_wandb.py`` (RGB + RGBA images +
+    video at step=100), then decodes the persisted ``.wandb`` proto and
+    asserts every same-step key lands in the row at ``_step=100``.
+
+    Args:
+        tmp_path: Per-test temporary directory used as ``WANDB_DIR``.
+        monkeypatch: pytest fixture for setting wandb env vars.
+    """
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    monkeypatch.setenv("WANDB_DIR", str(tmp_path))
+    monkeypatch.setenv("WANDB_SILENT", "true")
+
+    h = WandBHandler(project="goggles_example_04_test", run_name="t")
+
+    rgb = np.random.randint(0, 255, (8, 8, 3), dtype=np.uint8)
+    rgba = np.random.randint(0, 255, (8, 8, 4), dtype=np.uint8)
+    vid = np.random.randint(0, 255, (4, 3, 8, 8), dtype=np.uint8)
+
+    for i in range(3):
+        h.handle(make_event(kind="metric", payload={"acc": i}, step=i))
+    h.handle(
+        SimpleNamespace(
+            kind="image",
+            scope="global",
+            payload=rgb,
+            step=100,
+            extra={"name": "Random image"},
+        )
+    )
+    h.handle(
+        SimpleNamespace(
+            kind="image",
+            scope="global",
+            payload=rgba,
+            step=100,
+            extra={"name": "Random RGBA image"},
+        )
+    )
+    h.handle(
+        SimpleNamespace(
+            kind="video",
+            scope="global",
+            payload=vid,
+            step=100,
+            extra={"name": "Random Video", "fps": 5, "format": "mp4"},
+        )
+    )
+    h.handle(make_event(kind="metric", payload={"next": 1}, step=101))
+    h.close()
+
+    matches = [
+        p
+        for p in glob.glob(
+            os.path.join(tmp_path, "**", "*.wandb"), recursive=True
+        )
+        if "latest-run" not in p
+    ]
+    assert matches, f"No .wandb proto under {tmp_path}"
+
+    by_step: dict[int, set[str]] = {}
+    ds = DataStore()
+    ds.open_for_scan(matches[0])
+    while True:
+        rec_data = ds.scan_record()
+        if rec_data is None:
+            break
+        rec = pb.Record()
+        rec.ParseFromString(rec_data[1])
+        kind = rec.WhichOneof("record_type")
+        if kind not in ("history", "partial_history"):
+            continue
+        items = getattr(rec, kind).item
+        step = None
+        keys = set()
+        for it in items:
+            key = it.key or (it.nested_key[0] if it.nested_key else "")
+            if key == "_step":
+                step = int(it.value_json)
+            elif not key.startswith("_"):
+                keys.add(key)
+        if step is not None:
+            by_step.setdefault(step, set()).update(keys)
+
+    assert 100 in by_step, f"step=100 row missing; rows={by_step}"
+    assert {"Random image", "Random RGBA image", "Random Video"} <= by_step[
+        100
+    ], (
+        "All three same-step media keys must land at step=100; "
+        f"got {sorted(by_step[100])}"
+    )


### PR DESCRIPTION
## Summary
- Closes #177. W&B panels for keys logged at the same step (e.g. `Random RGBA image` in example 04) sometimes showed "No data available" on the dev backend.
- `WandBHandler` issued one `run.log({...}, step=N)` per Goggles event, so example 04's four media events at `step=100` became four separate commits at the same step. The cloud backend treats repeated same-step commits as best-effort merges, which can leave a panel registered for one key but empty for siblings.
- Fix: buffer logs per `(scope, step)` in a small pending dict and flush a single `run.log` on step change or `close()`. Complements the existing `StepGuard` (which only enforces non-decreasing steps).
- Artifacts still bypass the buffer (they're step-less). `step=None` events also bypass it so wandb's auto-increment semantics are preserved for callers that don't pin a step.

## Test plan
- [x] `uv run pytest tests/core/integrations/test_wandb.py` — 46 passed (42 pre-existing + 4 new).
- [x] Adjusted the four pre-existing tests that asserted on immediate-commit semantics (`test_handle_drops_backward_step_with_warning`, `test_handle_allows_equal_and_forward_steps`, `test_handle_tracks_step_per_scope`, plus the vector_field/trajectories pair) to either flush via `close()` or assert the new batched-commit shape.
- [x] New unit tests cover: same-step batching into one commit (`test_same_step_events_batch_into_single_log_call`), `close()` flushes pending (`test_close_flushes_pending_buffer`), and `step=None` bypasses the buffer to preserve auto-increment (`test_step_none_bypasses_buffer_to_preserve_autoincrement`).
- [x] New `@pytest.mark.slow` end-to-end test (`test_example_04_logs_all_keys_at_step_100_offline`) drives the real `wandb` client in offline mode, decodes the `.wandb` proto via `wandb.sdk.internal.datastore`, and asserts all of example 04's same-step keys land in the row at `_step=100`. Registered the `slow` marker in `pyproject.toml`.
- [x] `uv run pre-commit run --files goggles/_core/integrations/wandb.py tests/core/integrations/test_wandb.py pyproject.toml` — ruff + ruff-format + format hooks pass. The remaining pydoclint complaints are all pre-existing on `dev` HEAD; this PR adds none and incidentally fixes a couple.
- [x] Manual: run `examples/04_wandb.py` against the dev W&B backend and confirm the `Random RGBA image` panel now shows the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)