### PR TITLE
fix(shutdown): default to unbounded wait, confirm per-handler close

### DIFF
--- a/examples/04_wandb.py
+++ b/examples/04_wandb.py
@@ -1,5 +1,4 @@
 import tempfile
-import time
 from collections.abc import Callable
 from pathlib import Path
 
@@ -309,8 +308,9 @@ try:
             data, name="Dynamic Random Values Histogram", step=154 + i
         )
 
-    time.sleep(2)
-    # When using asynchronous logging (like wandb), make sure to finish
+    # When using asynchronous logging (like wandb), make sure to finish.
+    # ``gg.finish()`` waits indefinitely by default so no queued events are
+    # dropped; pass ``timeout=T`` if you need a bound.
     gg.finish()
 finally:
     artifact_dir.cleanup()

--- a/goggles/__init__.py
+++ b/goggles/__init__.py
@@ -824,20 +824,62 @@ class EventBus:
         self.scopes: dict[str, set[str]] = defaultdict(set)
         self._lock = threading.RLock()
 
-    def shutdown(self) -> None:
-        """Shutdown the EventBus and close all handlers."""
+    def shutdown(self, timeout: float | None = None) -> None:
+        """Close every attached handler and clear scope state.
+
+        Every ``handler.close()`` is launched in its own daemon thread
+        so slow handlers run concurrently. Each thread is then joined
+        with ``timeout`` seconds; clean exits log a debug confirmation
+        and timeouts log a warning.
+
+        Args:
+            timeout: Per-handler close budget in seconds. ``None`` waits
+                indefinitely. On timeout the close thread is abandoned —
+                Python cannot safely interrupt blocking I/O — and the
+                handler may continue running in the background.
+        """
         with self._lock:
-            copy_map = {
-                scope: handlers_names.copy()
-                for scope, handlers_names in self.scopes.items()
-            }
-        for scope, handlers_names in copy_map.items():
-            for handler_name in handlers_names:
-                try:
-                    self.detach(handler_name, scope)
-                except ValueError:
-                    # Another thread may have already detached this pair.
-                    pass
+            handlers_to_close = list(self.handlers.values())
+            self.handlers.clear()
+            self.scopes.clear()
+
+        threads: list[tuple[threading.Thread, Handler]] = []
+        for handler in handlers_to_close:
+            t = threading.Thread(
+                target=self._close_handler_safely,
+                args=(handler,),
+                daemon=True,
+                name=f"goggles-close-{handler.name}",
+            )
+            t.start()
+            threads.append((t, handler))
+
+        log = logging.getLogger(__name__)
+        for t, handler in threads:
+            t.join(timeout=timeout)
+            if t.is_alive():
+                log.warning(
+                    "Handler '%s' did not confirm close within %.1fs; "
+                    "abandoning (thread continues as daemon).",
+                    handler.name,
+                    -1.0 if timeout is None else timeout,
+                )
+            else:
+                log.debug("Handler '%s' close confirmed.", handler.name)
+
+    @staticmethod
+    def _close_handler_safely(handler: Handler) -> None:
+        """Run ``handler.close()`` and log any exception it raises.
+
+        Args:
+            handler: Handler to close.
+        """
+        try:
+            handler.close()
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "Handler '%s' raised in close()", handler.name
+            )
 
     def attach(self, handlers: list[dict], scopes: list[str]) -> None:
         """Attach handler(s) under the given scopes.
@@ -1066,14 +1108,22 @@ def detach(handler_name: str, scope: str) -> None:
 def finish(timeout: float | None = None) -> None:
     """Shutdown the global transport and close all handlers.
 
+    Default behavior is to wait indefinitely so no queued events are
+    silently dropped. Pass an explicit ``timeout`` to bound the wait —
+    on timeout, the rest of the drain queue is discarded and any
+    handler still inside ``close()`` is abandoned (the thread continues
+    as a daemon). Both events are logged.
+
     Args:
-        timeout: Optional timeout in seconds for shutdown completion.
-            If None, uses ``GOGGLES_SHUTDOWN_TIMEOUT`` (default: 5.0s).
-            Set to 0 or a negative value to wait indefinitely.
+        timeout: Optional bound in seconds applied to (a) draining queued
+            events into handlers and (b) each handler's ``close()`` call.
+            If ``None``, falls back to the ``GOGGLES_SHUTDOWN_TIMEOUT``
+            env var; an unset env var or a non-positive value means no
+            deadline.
     """
     bus = get_bus()
     if timeout is None:
-        timeout = float(os.getenv("GOGGLES_SHUTDOWN_TIMEOUT", "5.0"))
+        timeout = float(os.getenv("GOGGLES_SHUTDOWN_TIMEOUT", "0"))
     if timeout <= 0:
         timeout = None
     try:

--- a/goggles/_core/transport/_local.py
+++ b/goggles/_core/transport/_local.py
@@ -153,6 +153,12 @@ class LocalTransport:
         self._client_sockets_lock = threading.Lock()
         self._drain_queue: queue.SimpleQueue[Any] = queue.SimpleQueue()
         self._drain_thread: threading.Thread | None = None
+        # Set during a bounded shutdown after the drain join times out:
+        # the drain loop then discards remaining queued events instead of
+        # forwarding them to handlers. Keeps shutdown semantics honest
+        # (handlers see "nothing more is coming") and stops new
+        # ``handler.handle()`` calls from racing ``handler.close()``.
+        self._drain_aborted = threading.Event()
 
         # Client-side state
         self._client_sock: socket.socket | None = None
@@ -413,6 +419,10 @@ class LocalTransport:
             item = self._drain_queue.get()
             if item is _SENTINEL:
                 return
+            if self._drain_aborted.is_set():
+                # Bounded shutdown timed out: discard the remaining queue
+                # rather than dispatching it concurrently with close().
+                continue
             try:
                 self._bus.emit(item)
             except Exception:
@@ -685,13 +695,23 @@ class LocalTransport:
                 remaining = self._drain_queue.qsize()
                 _log.warning(
                     "goggles host shutdown: drain did not finish within "
-                    "%.1fs; %d events will not reach handlers",
+                    "%.1fs; %d queued events will be discarded",
                     timeout if timeout is not None else -1.0,
                     remaining,
                 )
+                # Tell the loop to stop dispatching; it will drain the
+                # rest of the queue as discards and exit at the SENTINEL.
+                # Wait briefly for that — once dispatch is bypassed the
+                # loop is fast. If the in-flight ``handler.handle()``
+                # call is still running, the thread won't exit until it
+                # returns; that's a race we can't safely interrupt, but
+                # marking the abort first means no further events are
+                # forwarded after this point.
+                self._drain_aborted.set()
+                self._drain_thread.join(timeout=timeout)
 
         try:
-            self._bus.shutdown()
+            self._bus.shutdown(timeout=timeout)
         except Exception:
             _log.exception("EventBus.shutdown raised")
 

--- a/tests/core/test_transport.py
+++ b/tests/core/test_transport.py
@@ -13,7 +13,7 @@ import time
 from collections.abc import Callable, Iterator
 from multiprocessing import shared_memory
 from pathlib import Path
-from typing import ClassVar, cast
+from typing import Any, ClassVar, cast
 
 import numpy as np
 import pytest
@@ -986,6 +986,208 @@ def test_shutdown_flushes_shm_frames(socket_path: str) -> None:
             pass
     finally:
         host.shutdown(timeout=5.0)
+
+
+class _SlowHandler:
+    """Handler whose ``handle()`` and ``close()`` each sleep on call.
+
+    Used to drive shutdown timeout paths: long ``handle`` calls block the
+    drain thread; long ``close`` calls block ``EventBus.shutdown``.
+
+    Attributes:
+        name: Handler identifier.
+        capabilities: Event kinds claimed (all of them, for convenience).
+    """
+
+    name = "slow"
+    capabilities: ClassVar[frozenset[Kind]] = frozenset(
+        {"log", "metric", "image", "video", "artifact", "histogram"}
+    )
+
+    def __init__(
+        self, handle_delay: float = 0.0, close_delay: float = 0.0
+    ) -> None:
+        """Initialize the handler with configurable per-call delays.
+
+        Args:
+            handle_delay: Seconds each ``handle`` call sleeps before counting.
+            close_delay: Seconds ``close`` sleeps before returning.
+        """
+        self.handle_delay = handle_delay
+        self.close_delay = close_delay
+        self.handled = 0
+        self.closed = False
+        self._lock = threading.Lock()
+
+    def can_handle(self, kind: Kind) -> bool:
+        del kind
+        return True
+
+    def handle(self, event: Event) -> None:
+        del event
+        if self.handle_delay > 0:
+            time.sleep(self.handle_delay)
+        with self._lock:
+            self.handled += 1
+
+    def open(self) -> None: ...
+
+    def close(self) -> None:
+        if self.close_delay > 0:
+            time.sleep(self.close_delay)
+        self.closed = True
+
+    def to_dict(self) -> dict:
+        return {"cls": "_SlowHandler", "data": {}}
+
+    @classmethod
+    def from_dict(cls, serialized: dict) -> _SlowHandler:
+        del serialized
+        return cls()
+
+
+def _install_handler(
+    transport: LocalTransport, handler: _SlowHandler
+) -> None:
+    """Install ``handler`` directly into ``transport``'s host bus.
+
+    Args:
+        transport: Host-mode transport that owns the bus.
+        handler: Handler to wire under the ``global`` scope.
+    """
+    with transport._bus._lock:  # type: ignore[attr-defined]
+        transport._bus.handlers[handler.name] = cast(Any, handler)  # type: ignore[attr-defined]
+        transport._bus.scopes["global"] = {handler.name}  # type: ignore[attr-defined]
+
+
+def test_shutdown_default_timeout_waits_for_slow_drain(
+    socket_path: str,
+) -> None:
+    """``shutdown(timeout=None)`` must wait for every queued event.
+
+    Pre-fix, ``gg.finish()`` defaulted to a 5s drain budget and silently
+    dropped the tail when slow handlers couldn't keep up. The new default
+    is no deadline, so all events delivered before shutdown must reach
+    the handler regardless of how slow it is.
+
+    Args:
+        socket_path: Endpoint path (via fixture).
+    """
+    transport = LocalTransport(socket_path=socket_path)
+    handler = _SlowHandler(handle_delay=0.05)  # ~50 events at 0.05s = 2.5s
+    n = 50
+    try:
+        _install_handler(transport, handler)
+        for i in range(n):
+            transport.emit(
+                Event(
+                    kind="log",
+                    scope="global",
+                    payload=f"m{i}",
+                    filepath="t.py",
+                    lineno=i,
+                )
+            )
+    finally:
+        # timeout=None — must wait until drain finishes, however long.
+        transport.shutdown(timeout=None)
+    assert handler.handled == n, (
+        f"All {n} events must reach the handler under default no-timeout "
+        f"shutdown; got {handler.handled}"
+    )
+    assert handler.closed, (
+        "Handler must be closed by shutdown when no timeout is set"
+    )
+
+
+def test_shutdown_drain_timeout_discards_remaining_queue(
+    socket_path: str,
+) -> None:
+    """When drain times out, the rest of the queue is dropped, not flushed.
+
+    The handle call in flight when the timeout fires runs to completion
+    (Python cannot interrupt blocking I/O), but every event still in
+    the queue must be discarded — so dispatch does not race
+    ``handler.close()`` for arbitrary additional events.
+
+    Args:
+        socket_path: Endpoint path (via fixture).
+    """
+    transport = LocalTransport(socket_path=socket_path)
+    # Each handle call takes 0.5s; with 20 events queued, draining all
+    # would take ~10s. A 0.2s shutdown timeout fires after ~event 1.
+    n = 20
+    handler = _SlowHandler(handle_delay=0.5)
+    try:
+        _install_handler(transport, handler)
+        for i in range(n):
+            transport.emit(
+                Event(
+                    kind="log",
+                    scope="global",
+                    payload=f"m{i}",
+                    filepath="t.py",
+                    lineno=i,
+                )
+            )
+    finally:
+        transport.shutdown(timeout=0.2)
+
+    # Wait long enough for any in-flight handle() to finish but well
+    # short of what would be needed to drain all 20 events serially.
+    time.sleep(1.0)
+    # The in-flight call may push handled to 1; the abort flag must
+    # have stopped the rest from being dispatched.
+    assert handler.handled <= 2, (
+        f"Drain abort must discard the queued tail; processed "
+        f"{handler.handled}/{n} events (expected at most 2)"
+    )
+    assert handler.closed, "Handler must be closed after shutdown"
+
+
+def test_shutdown_per_handler_close_is_bounded(socket_path: str) -> None:
+    """``shutdown(timeout=T)`` must abandon a hung ``handler.close()``.
+
+    Args:
+        socket_path: Endpoint path (via fixture).
+    """
+    transport = LocalTransport(socket_path=socket_path)
+    # close() sleeps for 5s, but we only wait 0.3s.
+    handler = _SlowHandler(close_delay=5.0)
+    _install_handler(transport, handler)
+    start = time.monotonic()
+    transport.shutdown(timeout=0.3)
+    elapsed = time.monotonic() - start
+    # Worst case: drain (~0) + drain-abort retry (~0) + close (0.3s).
+    # Allow generous slack for thread scheduling jitter.
+    assert elapsed < 2.5, (
+        f"Bounded shutdown must not block on a hung close(); "
+        f"took {elapsed:.2f}s"
+    )
+    # The handler thread is still running close(); we did not interrupt
+    # it, but we returned without waiting for it.
+    assert not handler.closed, (
+        "close() should still be in-flight (sleep=5s, timeout=0.3s)"
+    )
+
+
+def test_shutdown_default_waits_for_slow_close(socket_path: str) -> None:
+    """``shutdown(timeout=None)`` must wait for ``handler.close()``.
+
+    Pre-fix, ``gg.finish()`` had a 5s default that bounded the wait;
+    a slow ``close()`` (e.g. wandb's ``run.finish()``) could be
+    abandoned. With the new default, close must complete cleanly.
+
+    Args:
+        socket_path: Endpoint path (via fixture).
+    """
+    transport = LocalTransport(socket_path=socket_path)
+    handler = _SlowHandler(close_delay=0.5)
+    _install_handler(transport, handler)
+    transport.shutdown(timeout=None)
+    assert handler.closed, (
+        "Handler.close() must complete cleanly under no-timeout shutdown"
+    )
 
 
 def test_shm_unlinked_on_client_send_failure(socket_path: str) -> None:

--- a/tests/test_top_level_api.py
+++ b/tests/test_top_level_api.py
@@ -1,4 +1,6 @@
 import sys
+import threading
+import time
 import types
 from typing import Any, ClassVar, cast
 
@@ -177,6 +179,115 @@ def test_eventbus_detach_and_shutdown():
     bus.attach([handler_data], scopes=["train", "test"])
     bus.shutdown()
     assert not bus.handlers, "Bus should have no handlers after shutdown"
+
+
+class _SlowCloseHandler:
+    """Test handler whose ``close()`` blocks for a configurable delay.
+
+    Attributes:
+        capabilities: Event kinds claimed (just metric/log here).
+    """
+
+    capabilities: ClassVar[frozenset[gg.Kind]] = cast(
+        frozenset[gg.Kind], frozenset({"metric", "log"})
+    )
+
+    def __init__(self, name: str = "slow", close_delay: float = 0.0) -> None:
+        """Initialize a handler whose ``close`` blocks for ``close_delay``.
+
+        Args:
+            name: Handler name used as registry key.
+            close_delay: Seconds ``close`` sleeps before returning.
+        """
+        self.name = name
+        self.close_delay = close_delay
+        self.closed = False
+        self.close_started = threading.Event()
+
+    def can_handle(self, kind: gg.Kind) -> bool:
+        return kind in self.capabilities
+
+    def handle(self, event: gg.Event) -> None:
+        del event
+
+    def open(self) -> None: ...
+
+    def close(self) -> None:
+        self.close_started.set()
+        if self.close_delay > 0:
+            time.sleep(self.close_delay)
+        self.closed = True
+
+    def to_dict(self) -> dict:
+        return {
+            "cls": "_SlowCloseHandler",
+            "data": {"name": self.name, "close_delay": self.close_delay},
+        }
+
+    @classmethod
+    def from_dict(cls, serialized: dict) -> "_SlowCloseHandler":
+        return cls(**serialized)
+
+
+def test_eventbus_shutdown_default_waits_for_slow_close():
+    """``shutdown()`` with no timeout must wait for ``close()`` to return."""
+    gg.register_handler(_SlowCloseHandler)
+    bus = gg.EventBus()
+    handler = _SlowCloseHandler(name="h1", close_delay=0.3)
+    bus.attach([handler.to_dict()], scopes=["train"])
+    attached = cast(_SlowCloseHandler, bus.handlers["h1"])
+    bus.shutdown()  # timeout=None
+    assert attached.closed, "Default shutdown must wait for close() to complete"
+    assert not bus.handlers, "Handlers must be cleared after shutdown"
+
+
+def test_eventbus_shutdown_timeout_abandons_hung_close():
+    """``shutdown(timeout=T)`` must return without blocking on a hung close."""
+    gg.register_handler(_SlowCloseHandler)
+    bus = gg.EventBus()
+    handler = _SlowCloseHandler(name="h1", close_delay=5.0)
+    bus.attach([handler.to_dict()], scopes=["train"])
+    attached = cast(_SlowCloseHandler, bus.handlers["h1"])
+    start = time.monotonic()
+    bus.shutdown(timeout=0.2)
+    elapsed = time.monotonic() - start
+    assert elapsed < 2.0, (
+        f"Bounded shutdown must not block on hung close(); took {elapsed:.2f}s"
+    )
+    assert attached.close_started.is_set(), (
+        "close() must have been invoked even though we did not wait for it"
+    )
+    assert not attached.closed, (
+        "close() should still be running (sleep=5s, timeout=0.2s)"
+    )
+    assert not bus.handlers, (
+        "Handlers must still be cleared after timed-out shutdown"
+    )
+
+
+def test_eventbus_shutdown_closes_all_handlers_in_parallel():
+    """Slow handlers must close concurrently, not one-after-another.
+
+    Each handler sleeps ``delay`` seconds in close(). Serial close would
+    take ~``n*delay``; parallel close should finish in roughly ``delay``.
+    """
+    gg.register_handler(_SlowCloseHandler)
+    bus = gg.EventBus()
+    n = 4
+    delay = 0.3
+    for i in range(n):
+        handler = _SlowCloseHandler(name=f"h{i}", close_delay=delay)
+        bus.attach([handler.to_dict()], scopes=[f"s{i}"])
+    start = time.monotonic()
+    bus.shutdown()
+    elapsed = time.monotonic() - start
+    # Generous slack for thread scheduling jitter, but well below the
+    # serial baseline of n*delay = 1.2s.
+    assert elapsed < n * delay * 0.75, (
+        f"Close threads should run in parallel; serial baseline {n * delay}s, "
+        f"parallel observed {elapsed:.2f}s"
+    )
+    assert not bus.handlers, "All handlers must be cleared after shutdown"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #179.

## Summary

- `gg.finish()` defaults to no deadline; queued events are no longer silently dropped on slow Windows/WSL setups.
- `EventBus.shutdown(timeout=None)` runs each `handler.close()` on its own daemon thread (so slow handlers close concurrently), joins with the supplied timeout, and logs per-handler confirmation/timeout.
- On drain timeout, `LocalTransport` sets a `_drain_aborted` flag so the drain loop discards the remaining queue instead of dispatching it concurrently with `close()`.
- `examples/04_wandb.py` no longer needs the `time.sleep(2)` workaround.

## Behavior change

`gg.finish()` (and `GOGGLES_SHUTDOWN_TIMEOUT` defaulted to `5.0`) used to bound shutdown at 5 seconds and silently dropped any queued events that did not drain in time. The new default is **wait indefinitely**. Pass `gg.finish(timeout=T)` (or set `GOGGLES_SHUTDOWN_TIMEOUT=T`) to opt back into a bounded shutdown — the bound applies to the drain phase and to each `handler.close()`.

## Test plan

- [x] `uv run pytest` — 624 pass, 4 platform-skipped (no regressions).
- [x] `uv run pre-commit run --files <changed>` — ruff + pydoclint clean.
- [x] `uv run pre-commit run --files <changed> --hook-stage pre-push` — basedpyright clean (only pre-existing wandb-proto errors remain on dev).
- [x] New tests in `tests/core/test_transport.py`:
  - `test_shutdown_default_timeout_waits_for_slow_drain` — 50 slow events all reach the handler under default no-timeout shutdown.
  - `test_shutdown_drain_timeout_discards_remaining_queue` — bounded shutdown drops the queue tail instead of dispatching it.
  - `test_shutdown_per_handler_close_is_bounded` — bounded shutdown returns without blocking on a 5s `close()`.
  - `test_shutdown_default_waits_for_slow_close` — default shutdown waits for slow `close()` to return cleanly.
- [x] New tests in `tests/test_top_level_api.py`:
  - `test_eventbus_shutdown_default_waits_for_slow_close`
  - `test_eventbus_shutdown_timeout_abandons_hung_close`
  - `test_eventbus_shutdown_closes_all_handlers_in_parallel` — 4 handlers × 0.3s close each finishes well under the 1.2s serial baseline.
