### PR TITLE
build: ship py.typed marker for PEP 561 (closes #190)

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -1,6 +1,9 @@
 name: Coding style validation
 
 on:
+    push:
+        branches:
+            - '**'
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -21,12 +21,25 @@ jobs:
               with:
                   python-version: '3.10'
 
-            # Step 3: Install dependencies
+            # Step 3: Install uv
+            #
+            # The pydoclint hook is `entry: uv run pydoclint`, so the runner
+            # needs uv on PATH at pre-commit time.
+            - name: Install uv
+              uses: astral-sh/setup-uv@v3
+              with:
+                  version: "latest"
+
+            # Step 4: Install dependencies
             - name: Install dependencies
               run: |
                   python -m pip install --upgrade pip
                   pip install pre-commit
 
-            # Step 4: Run pre-commit hooks
+            # Step 5: Sync dev extras so `uv run pydoclint` resolves
+            - name: Install dev extras (provides pydoclint)
+              run: uv sync --extra dev
+
+            # Step 6: Run pre-commit hooks
             - name: Run pre-commit
               run: pre-commit run --all-files

--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -1,6 +1,9 @@
 name: Commit style validation
 
 on:
+    push:
+        branches:
+            - '**'
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,9 @@
 name: Python CI
 
 on:
+    push:
+        branches:
+            - '**'
     workflow_dispatch:
 
 jobs:

--- a/goggles/_core/integrations/__init__.py
+++ b/goggles/_core/integrations/__init__.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     # Static analyzers can't see the runtime __getattr__ + find_spec dance,
     # so import the symbol unconditionally for type checking. At runtime,
     # the import is gated on the wandb extra being installed.
-    from .wandb import WandBHandler
+    from .wandb import WandBHandler  # noqa: F401
 
 __all__: list[str] = [
     "ConsoleHandler",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,9 @@ allow-init-docstring = true
 arg-type-hints-in-docstring = false
 check-return-types = false
 skip-checking-raises = false
+# Match the ruff per-file-ignore policy: tests and examples are
+# documented via comments/READMEs, not Google-style docstrings.
+exclude = '\.git|\.tox|tests/.*|examples/.*'
 
 # Pyright configuration for type checking
 # We use basedpyright but in this way pylance also

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: System :: Logging",
+    "Typing :: Typed",
 ]
 dependencies = [
     "ruamel.yaml",
@@ -45,6 +46,9 @@ Issues = "https://github.com/antonioterpin/goggles/issues"
 [tool.setuptools.packages.find]
 include = ["goggles*"]
 exclude = ["wandb*", "tests*", "examples*"]
+
+[tool.setuptools.package-data]
+goggles = ["py.typed"]
 
 [project.optional-dependencies]
 # Development and examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ dependencies = [
     "numpy>=1.23",
     "imageio>=2.37.0",
     "matplotlib>=3.10.7",
-    "basedpyright",
-    "pydoclint>=0.8.3",
 ]
 
 [project.urls]
@@ -61,6 +59,8 @@ dev = [
     "pyupgrade>=3.19.0",
     "psutil",
     "hydra-core>=1.3.2",
+    "basedpyright",
+    "pydoclint>=0.8.3",
 ]
 # Optional JAX-based GPU history subsystem
 jax = [

--- a/uv.lock
+++ b/uv.lock
@@ -2150,12 +2150,10 @@ name = "robo-goggles"
 version = "0.1.9"
 source = { editable = "." }
 dependencies = [
-    { name = "basedpyright" },
     { name = "imageio" },
     { name = "matplotlib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydoclint" },
     { name = "rich" },
     { name = "ruamel-yaml" },
     { name = "typing-extensions" },
@@ -2163,10 +2161,12 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "basedpyright" },
     { name = "hydra-core" },
     { name = "hypothesis" },
     { name = "pre-commit" },
     { name = "psutil" },
+    { name = "pydoclint" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -2187,7 +2187,7 @@ wandb = [
 
 [package.metadata]
 requires-dist = [
-    { name = "basedpyright" },
+    { name = "basedpyright", marker = "extra == 'dev'" },
     { name = "hydra-core", marker = "extra == 'dev'", specifier = ">=1.3.2" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "imageio", specifier = ">=2.37.0" },
@@ -2198,7 +2198,7 @@ requires-dist = [
     { name = "plotly", marker = "extra == 'wandb'", specifier = ">=5.20.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.0.1" },
     { name = "psutil", marker = "extra == 'dev'" },
-    { name = "pydoclint", specifier = ">=0.8.3" },
+    { name = "pydoclint", marker = "extra == 'dev'", specifier = ">=0.8.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Summary
- Add empty \`goggles/py.typed\`.
- Register it via \`[tool.setuptools.package-data] goggles = [\"py.typed\"]\`.
- Add the \`Typing :: Typed\` classifier.

Stacked on #196 → #195. Retarget to \`dev\` before merging.

Closes #190.

## Test plan
- [ ] \`uv build\` produces a wheel that contains \`goggles/py.typed\`.
- [ ] \`unzip -p dist/*.whl '*/METADATA' | grep Typing\` shows \`Classifier: Typing :: Typed\`.
- [ ] Downstream basedpyright run against \`import goggles\` resolves types instead of \`Any\`.