### PR TITLE
build(deps)!: move basedpyright + pydoclint to dev extra (closes #189)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ dependencies = [
     "numpy>=1.23",
     "imageio>=2.37.0",
     "matplotlib>=3.10.7",
-    "basedpyright",
-    "pydoclint>=0.8.3",
 ]
 
 [project.urls]
@@ -61,6 +59,8 @@ dev = [
     "pyupgrade>=3.19.0",
     "psutil",
     "hydra-core>=1.3.2",
+    "basedpyright",
+    "pydoclint>=0.8.3",
 ]
 # Optional JAX-based GPU history subsystem
 jax = [

--- a/uv.lock
+++ b/uv.lock
@@ -2150,12 +2150,10 @@ name = "robo-goggles"
 version = "0.1.9"
 source = { editable = "." }
 dependencies = [
-    { name = "basedpyright" },
     { name = "imageio" },
     { name = "matplotlib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydoclint" },
     { name = "rich" },
     { name = "ruamel-yaml" },
     { name = "typing-extensions" },
@@ -2163,10 +2161,12 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "basedpyright" },
     { name = "hydra-core" },
     { name = "hypothesis" },
     { name = "pre-commit" },
     { name = "psutil" },
+    { name = "pydoclint" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -2187,7 +2187,7 @@ wandb = [
 
 [package.metadata]
 requires-dist = [
-    { name = "basedpyright" },
+    { name = "basedpyright", marker = "extra == 'dev'" },
     { name = "hydra-core", marker = "extra == 'dev'", specifier = ">=1.3.2" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "imageio", specifier = ">=2.37.0" },
@@ -2198,7 +2198,7 @@ requires-dist = [
     { name = "plotly", marker = "extra == 'wandb'", specifier = ">=5.20.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.0.1" },
     { name = "psutil", marker = "extra == 'dev'" },
-    { name = "pydoclint", specifier = ">=0.8.3" },
+    { name = "pydoclint", marker = "extra == 'dev'", specifier = ">=0.8.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Summary
- \`basedpyright\` and \`pydoclint\` were listed under \`[project.dependencies]\`, so every \`pip install robo-goggles\` pulled a type checker + docstring linter despite neither being imported at runtime.
- Move both to \`[project.optional-dependencies].dev\`. Re-locked \`uv.lock\`.
- Verified the built wheel's METADATA lists both under \`extra == \"dev\"\` only, not as unconditional Requires-Dist.

Replaces #196 (which was auto-closed when its base \`release-prep-185-ci-triggers\` was deleted on the merge of #195).

Closes #189.

## Test plan
- [ ] \`uv build\` succeeds; \`unzip -p dist/*.whl '*/METADATA' | grep -E '^Requires-Dist'\` shows basedpyright/pydoclint only with \`extra == \"dev\"\`.
- [ ] \`uv sync --extra dev\` still resolves them for contributors.
- [ ] CI green.