### PR TITLE
ci: add tag-driven PyPI release workflow with OIDC (closes #186)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+    push:
+        tags:
+            - 'v*'
+
+permissions:
+    contents: write   # gh release create
+    id-token: write   # PyPI OIDC trusted publishing
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        # Scope the OIDC token to the `pypi` GitHub environment so the
+        # PyPI trusted-publisher claim can pin to it. Configure the
+        # environment + the matching trusted publisher on PyPI before
+        # the first release.
+        environment:
+            name: pypi
+            url: https://pypi.org/p/robo-goggles
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0   # full history -> previous-tag lookup
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v6
+              with:
+                  python-version: '3.12'
+
+            - name: Verify tag matches pyproject.toml version
+              run: |
+                  TAG="${GITHUB_REF#refs/tags/}"
+                  TAG_VERSION="${TAG#v}"
+                  PYPROJECT_VERSION=$(
+                      awk -F'"' '/^version = /{print $2; exit}' pyproject.toml
+                  )
+                  if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+                      echo "::error::Tag $TAG ($TAG_VERSION) does not match pyproject.toml version ($PYPROJECT_VERSION)"
+                      exit 1
+                  fi
+                  echo "Tag $TAG matches pyproject.toml version $PYPROJECT_VERSION"
+
+            - name: Build distribution
+              run: uv build
+
+            - name: Verify metadata with twine
+              run: uv run --with twine twine check dist/*
+
+            - name: Publish to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+
+            - name: Create GitHub Release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  TAG="${GITHUB_REF#refs/tags/}"
+                  PREV_TAG=$(
+                      git tag --sort=-v:refname \
+                          | grep -A1 "^${TAG}$" \
+                          | tail -n1
+                  )
+                  if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$TAG" ]; then
+                      gh release create "$TAG" \
+                          --title "$TAG" \
+                          --generate-notes \
+                          --notes-start-tag "$PREV_TAG"
+                  else
+                      gh release create "$TAG" \
+                          --title "$TAG" \
+                          --generate-notes
+                  fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to `robo-goggles` are documented here. The format is
+based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
+project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(pre-1.0: minor bumps may carry breaking changes).
+
+## [0.2.0] - 2026-05-01
+
+First release after a substantial rework of the transport layer, the
+configuration surface, and the public API. **Pre-1.0 versioning rules
+apply: this is a breaking release.** Pin to `>=0.1.9,<0.2` if you need
+the old behavior.
+
+### Breaking
+
+- **Transport: replace portal RPC with Unix-socket `LocalTransport`.**
+  The cross-process backbone is now an in-tree Unix-socket transport
+  with explicit framing; the `portal` runtime dependency is gone.
+  (#143)
+- **Transport: split `transport.py` into a focused package.** Internal
+  imports moved under `goggles._core.transport.*`. Public surface
+  imported via `goggles` is unchanged; direct imports of internal
+  paths must be updated. (#163)
+- **Config: drop CLI override helpers.** The `from_cli`-style override
+  helpers were removed. Use Hydra/argparse upstream and pass the
+  resolved config to `from_config`. (#150)
+- **Config: reject private-field overrides in `from_config`.** Keys
+  with a leading underscore now raise instead of being silently
+  applied. (#155)
+
+### Added
+
+- **`gg.configure()`** shortcut for the common console-only setup. (#166)
+- **Per-logger `set_level`** + `level=` kwarg on `get_logger`. (#169)
+- **`logger.trajectories`** for particle trajectory logging. (#148)
+- **JIT-compatible filter API** (`init_state` + `apply`). (#176)
+- **Outliers-rejection filters** + filter registry pluggability. (#119, #105)
+- **W&B handler**: vector-field support, `tags=` forwarded to
+  `wandb.init`, per-scope monotonic-step guard. (#125, #174, #172)
+- **Image promotion**: image-shaped values passed to `push()` are
+  routed to the image handlers. (#156)
+- **Out-of-order step policy** unified across `LocalStorage` and
+  console handlers. (#165)
+- **Dict logging.** (#109)
+- **`PrettyConfig`** as a drop-in basic config class. (#100)
+- **`py.typed` marker** + `Typing :: Typed` classifier so downstream
+  type checkers consume goggles' types. (#190)
+
+### Changed
+
+- `basedpyright` and `pydoclint` are no longer runtime dependencies;
+  install with `pip install robo-goggles[dev]` to get them. (#189)
+- License metadata modernised to PEP 639 SPDX form. (#191)
+- CI workflows trigger automatically on push and pull-request; the
+  `code-style` job now installs `uv` so the `pydoclint` hook runs
+  in CI. (#185)
+- Dropped the `pyyaml` runtime dependency in favor of
+  `ruamel.yaml`. (#149)
+
+### Fixed
+
+- **Transport (Windows)**: require token handshake on TCP loopback so
+  unrelated local clients cannot attach. (#175)
+- **Shutdown**: default to unbounded wait and confirm per-handler
+  close, fixing premature exits. (#180)
+- **W&B**: batch same-step commits to fix unreliable display; do not
+  mutate shared `event.extra`; accept channels-last video tensors.
+  (#177, #147, #146)
+- **Logger**: resolve transport lazily so class-level loggers work
+  before the bus is attached. (#164)
+- **Filters**: initialize ring-buffer index in `__init__`. (#144)
+- **Typing**: covariant `Metrics` type. (#135)
+
+[0.2.0]: https://github.com/antonioterpin/goggles/compare/v0.1.9...v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robo-goggles"
-version = "0.1.9"
+version = "0.2.0"
 authors = [
     { name = "Antonio Terpin", email = "aterpin@ethz.ch" },
     { name = "Francesco Banelli", email = "fbanelli@ethz.ch" },

--- a/uv.lock
+++ b/uv.lock
@@ -2147,7 +2147,7 @@ wheels = [
 
 [[package]]
 name = "robo-goggles"
-version = "0.1.9"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "imageio" },


### PR DESCRIPTION
## Summary
Port tinyros's \`release.yaml\` to goggles. On \`v*\` tag push the workflow:
1. Verifies the tag matches \`pyproject.toml\` \`version\`.
2. Builds with \`uv build\` and runs \`twine check\`.
3. Publishes via PyPI OIDC trusted publisher scoped to the \`pypi\` GitHub environment.
4. Cuts a GitHub Release with notes anchored at the previous tag.

Stacked on #200. Targets \`dev\` directly.

Closes #186.

## Prerequisites (manual, before first tag)
- [ ] Create a \`pypi\` Environment in repo Settings → Environments.
- [ ] Configure a Trusted Publisher on PyPI for \`robo-goggles\` pinned to that environment + this workflow file.

## Test plan
- [ ] CI green on this PR (workflow only triggers on tags, so it won't run here).
- [ ] After merging the stack and tagging \`v0.2.0\`: workflow publishes to PyPI and creates the GH Release.