### PR TITLE
ci(commit-lint): ignore merge commits in conventional check

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -13,9 +13,6 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v6
             - name: Run Commitlint
-              # No configFile: there is no commitlint.config.{js,mjs} in
-              # the tree, so the action falls back to the bundled
-              # @commitlint/config-conventional defaults. The v5 pin had
-              # the same effective behaviour but accepted a missing .js
-              # path silently; v6 errors on it.
               uses: wagoid/commitlint-github-action@v6
+              with:
+                  configFile: commitlint.config.mjs

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,16 @@
+// Commitlint config for goggles.
+//
+// Inherits the standard `@commitlint/config-conventional` rules but
+// skips the merge commits GitHub creates when a PR with multiple
+// commits is merged (`Merge pull request ... from ...`) and the
+// merge commits `git merge` itself produces. Without this, every
+// merge-commit-style PR into main fails the commit-lint workflow.
+export default {
+    extends: ['@commitlint/config-conventional'],
+    ignores: [
+        (message) =>
+            /^Merge (pull request|branch|remote-tracking branch) /.test(
+                message,
+            ),
+    ],
+};


### PR DESCRIPTION
## Summary
PR #207 (the dev → main release-prep promotion) tripped commit-lint on \`main\` because the merge commit \`Merge pull request #207 from antonioterpin/dev\` doesn't match a conventional type. Same will happen on every future merge-commit-style PR.

Fix:
- Add \`commitlint.config.mjs\` extending \`@commitlint/config-conventional\` with an \`ignores\` predicate that matches \`Merge pull request|branch|remote-tracking branch ...\`.
- Point \`commit-lint.yaml\` back at \`configFile: commitlint.config.mjs\` (a few PRs ago we removed it because the older \`.js\` path failed under v6 — the \`.mjs\` form is what v6 wants).

Other commit subjects keep being linted normally.

## Test plan
- [ ] \`commit-lint\` job on this PR is green (regular conventional commit subject).
- [ ] After merging this fix into \`dev\` and a subsequent dev → main merge commit, \`commit-lint\` on \`main\` is green.