### PR TITLE
release: promote commit-lint fix to main

### DIFF
--- a/.github/workflows/commit-lint.yaml
+++ b/.github/workflows/commit-lint.yaml
@@ -13,9 +13,6 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v6
             - name: Run Commitlint
-              # No configFile: there is no commitlint.config.{js,mjs} in
-              # the tree, so the action falls back to the bundled
-              # @commitlint/config-conventional defaults. The v5 pin had
-              # the same effective behaviour but accepted a missing .js
-              # path silently; v6 errors on it.
               uses: wagoid/commitlint-github-action@v6
+              with:
+                  configFile: commitlint.config.mjs

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,16 @@
+// Commitlint config for goggles.
+//
+// Inherits the standard `@commitlint/config-conventional` rules but
+// skips the merge commits GitHub creates when a PR with multiple
+// commits is merged (`Merge pull request ... from ...`) and the
+// merge commits `git merge` itself produces. Without this, every
+// merge-commit-style PR into main fails the commit-lint workflow.
+export default {
+    extends: ['@commitlint/config-conventional'],
+    ignores: [
+        (message) =>
+            /^Merge (pull request|branch|remote-tracking branch) /.test(
+                message,
+            ),
+    ],
+};


### PR DESCRIPTION
## Summary
Roll forward the merge-commit ignore (#208) from \`dev\` to \`main\` so the next dev → main merge commit doesn't trip commit-lint again.

## Content
- 0797da2 \`ci(commit-lint): ignore merge commits in conventional check\`
- 92c651e merge commit from #208

## Test plan
- [ ] CI on this PR green (\`commit-lint\` should now be green on the merge commit too once this lands).
- [ ] After merge, run \`gh run list --branch main --limit 3\` and verify the resulting workflow run reports commit-lint as **pass**.

## After merge
\`main\` is then ready for tagging \`v0.2.0\` (assuming the PyPI Trusted Publisher + \`pypi\` Environment are configured).