### PR TITLE
ci(commit-lint): disable body/footer line-length limits

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -5,6 +5,12 @@
 // commits is merged (`Merge pull request ... from ...`) and the
 // merge commits `git merge` itself produces. Without this, every
 // merge-commit-style PR into main fails the commit-lint workflow.
+//
+// The body/footer line-length limits are disabled: footers carry
+// unwrappable trailers (long `Co-authored-by` emails, tool-injected
+// `Agent-Logs-Url:` URLs) that legitimately exceed 100 characters,
+// and the workflow re-lints merged history on every downstream push,
+// so a single long trailer would otherwise poison future merges.
 export default {
     extends: ['@commitlint/config-conventional'],
     ignores: [
@@ -13,4 +19,8 @@ export default {
                 message,
             ),
     ],
+    rules: {
+        'body-max-line-length': [0],
+        'footer-max-line-length': [0],
+    },
 };


### PR DESCRIPTION
## Problem

The "Commit style validation" workflow **failed on `main`** for the v0.2.1 release push ([run 26362989973](https://github.com/antonioterpin/goggles/actions/runs/26362989973)):

```
✖ footer's lines must not be longer than 100 characters [footer-max-line-length]
```

The offending line is an unwrappable URL trailer in the squashed `#210` commit:

```
Agent-Logs-Url: https://github.com/antonioterpin/goggles/sessions/bc2073e4-…   (102 chars)
```

This is structural, not a one-off:
- `config-conventional`'s `footer-max-line-length: 100` can't be satisfied by URL trailers or long `Co-authored-by` emails — they don't wrap.
- The workflow lints on **push to every branch** and re-checks all commits in the range, so a single long trailer re-fails on every downstream merge (it failed on its own `dev` push too, then again on the `main` release push).

## Fix

Disable `body-max-line-length` and `footer-max-line-length` in `commitlint.config.mjs`. Subject / type / scope rules stay enforced. Verified the previously-failing `#210` commit now lints clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)