### PR TITLE
ci(commit-lint): disable body/footer line-length limits

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -5,6 +5,12 @@
 // commits is merged (`Merge pull request ... from ...`) and the
 // merge commits `git merge` itself produces. Without this, every
 // merge-commit-style PR into main fails the commit-lint workflow.
+//
+// The body/footer line-length limits are disabled: footers carry
+// unwrappable trailers (long `Co-authored-by` emails, tool-injected
+// `Agent-Logs-Url:` URLs) that legitimately exceed 100 characters,
+// and the workflow re-lints merged history on every downstream push,
+// so a single long trailer would otherwise poison future merges.
 export default {
     extends: ['@commitlint/config-conventional'],
     ignores: [
@@ -13,4 +19,8 @@ export default {
                 message,
             ),
     ],
+    rules: {
+        'body-max-line-length': [0],
+        'footer-max-line-length': [0],
+    },
 };


### PR DESCRIPTION
Promote `dev` to `main`: the commit-lint line-length fix.

Disables `body-max-line-length` + `footer-max-line-length` in `commitlint.config.mjs` so unwrappable trailers (long `Co-authored-by` emails, `Agent-Logs-Url:` URLs) no longer fail the "Commit style validation" workflow. This is what broke the v0.2.1 release push to `main` ([run 26362989973](https://github.com/antonioterpin/goggles/actions/runs/26362989973)) via the `#210` squash commit's 102-char footer.

Subject / type / scope rules remain enforced. Merging this should turn the post-release commit-lint run on `main` green.

⚠️ When merging: do **not** click "Delete branch" — `dev` is the long-lived integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)