### PR TITLE
fix(wandb): flatten nested-dict metric metadata into selectable axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Changed
+
+- **W&B: nested-dict metric metadata is flattened to dotted scalar keys.** Any
+  nested dict logged alongside a metric/media event (e.g.
+  `logger.scalar("loss", v, step=i, custom_step={"time": t})`) now reaches
+  `wandb.log` as flat keys (`custom_step.time`) instead of a nested *object*
+  W&B can't select as a chart axis -- so a custom step / physical-time x-axis
+  works. This applies to all such values, not only the axis case; charts or
+  queries referencing the old nested key must switch to the dotted key. See
+  `examples/09_custom_step_axis.py`.
+
 ## [0.2.2] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ uv run examples/06_custom_handler.py
 # Dedicated host subprocess for handlers (the default) — and how to opt out
 uv run examples/08_dedicated_host.py
 
+# Custom W&B x-axis (e.g. physical time) instead of the step index
+uv run examples/09_custom_step_axis.py
+
 # Graceful shutdown utils
 uv run examples/100_interrupt.py
 

--- a/examples/04_wandb.py
+++ b/examples/04_wandb.py
@@ -316,9 +316,7 @@ try:
                 np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8),
                 name="Random image with custom step",
                 step=i,  # Global step
-                custom_step={
-                    "custom_step": i // 10 - 10
-                },  # Extra field to be used as x-axis
+                custom_step=i // 10 - 10,  # extra field usable as a W&B x-axis
             )
 
     # Log a static histogram (that does not change over time)

--- a/examples/09_custom_step_axis.py
+++ b/examples/09_custom_step_axis.py
@@ -1,0 +1,39 @@
+"""Example: a custom W&B x-axis (e.g. physical time) instead of the step index.
+
+Any numeric keyword passed to a metric call is logged in the same step, so it
+can be selected as the chart x-axis in W&B (instead of the default ``_step``).
+Nested dicts are flattened to dotted scalar keys
+(``custom_step={"time": t}`` -> ``custom_step.time``), which are selectable too.
+
+Run offline (no account needed):
+    WANDB_MODE=offline python examples/09_custom_step_axis.py
+"""
+
+import math
+
+import goggles as gg
+from goggles import WandBHandler
+
+logger: gg.GogglesLogger = gg.get_logger(
+    "examples.custom_step", with_metrics=True
+)
+gg.attach(
+    WandBHandler(project="goggles_custom_step", run_name="custom_step"),
+    scopes=["global"],
+)
+
+dt = 1.0 / 30.0  # a 30 Hz process
+for i in range(300):
+    t = i * dt
+    # `sim_time` is a flat axis; `custom_step={"time": t}` flattens to
+    # `custom_step.time` -- both selectable as the chart x-axis.
+    logger.scalar(
+        "signal",
+        math.sin(math.pi * t),
+        step=i,
+        sim_time=t,
+        custom_step={"time": t},
+    )
+
+gg.finish()
+print("In W&B, set the x-axis to `sim_time` or `custom_step.time`.")

--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -173,6 +173,36 @@ Reinit: TypeAlias = Literal[
 ]
 
 
+def _flatten_logs(
+    logs: Mapping[str, Any], _parent: str = "", _sep: str = "."
+) -> dict[str, Any]:
+    """Promote nested-dict values to flat dotted keys for W&B.
+
+    ``{"custom_step": {"time": t}}`` becomes ``{"custom_step.time": t}``. W&B
+    stores a nested dict as a multi-level object that can't be selected as a
+    chart axis; a flat scalar key can. Only ``Mapping`` values are descended
+    into -- media/other objects, scalars, and arrays pass through. On a key
+    collision (a literal dotted key and a flattened nested key) the last value
+    wins.
+
+    Args:
+        logs: Log keys to values; values may be nested mappings.
+        _parent: Internal -- dotted prefix accumulated during recursion.
+        _sep: Internal -- separator between nesting levels.
+
+    Returns:
+        A flat dict with nested-mapping values promoted to dotted keys.
+    """
+    flat: dict[str, Any] = {}
+    for key, value in logs.items():
+        full = f"{_parent}{_sep}{key}" if _parent else str(key)
+        if isinstance(value, Mapping):
+            flat.update(_flatten_logs(value, full, _sep))
+        else:
+            flat[full] = value
+    return flat
+
+
 class WandBHandler:
     """Forward Goggles events to W&B runs (supports concurrent scopes).
 
@@ -777,6 +807,7 @@ class WandBHandler:
             step: User-supplied step, or None for auto-increment.
             logs: Mapping of keys to values to merge into the commit.
         """
+        logs = _flatten_logs(logs)
         if step is None:
             self._flush_pending(scope)
             run.log(dict(logs))

--- a/tests/core/integrations/test_wandb.py
+++ b/tests/core/integrations/test_wandb.py
@@ -913,6 +913,88 @@ def test_close_flushes_pending_buffer(mock_wandb: MagicMock) -> None:
     run.finish.assert_called()
 
 
+def test_flatten_logs_promotes_nested_dicts_to_dotted_keys() -> None:
+    """Nested-mapping values are promoted to dotted scalar keys."""
+    flat = wandb_module._flatten_logs(
+        {
+            "loss": 0.5,
+            "custom_step": {"time": 1.5, "episode": 3},
+            "nested": {"a": {"b": 2}},
+        }
+    )
+    assert flat == {
+        "loss": 0.5,
+        "custom_step.time": 1.5,
+        "custom_step.episode": 3,
+        "nested.a.b": 2,
+    }
+
+
+def test_flatten_logs_leaves_non_mappings_untouched() -> None:
+    """Objects, scalars, arrays and list containers pass through by identity."""
+    sentinel = object()
+    arr = np.arange(3)
+    list_of_dicts = [{"a": 1}]
+    flat = wandb_module._flatten_logs(
+        {"obj": sentinel, "scalar": 7, "arr": arr, "lst": list_of_dicts}
+    )
+    assert flat["obj"] is sentinel
+    assert flat["scalar"] == 7
+    assert flat["arr"] is arr
+    assert flat["lst"] is list_of_dicts  # only Mapping values are descended
+
+
+def test_flatten_logs_drops_empty_nested_dict() -> None:
+    """An empty nested dict contributes no keys."""
+    assert wandb_module._flatten_logs({"a": {}, "b": 1}) == {"b": 1}
+
+
+def test_flatten_logs_collision_is_last_write_wins() -> None:
+    """A literal dotted key colliding with a flattened key: last wins."""
+    assert wandb_module._flatten_logs({"a.b": 1, "a": {"b": 2}}) == {"a.b": 2}
+    assert wandb_module._flatten_logs({"a": {"b": 2}, "a.b": 1}) == {"a.b": 1}
+
+
+def test_metric_nested_extra_logged_as_flat_axis(
+    mock_wandb: MagicMock,
+) -> None:
+    """A nested ``custom_step`` extra reaches ``run.log`` as a flat key."""
+    h = WandBHandler(project="p")
+    h.handle(
+        SimpleNamespace(
+            kind="metric",
+            scope="global",
+            payload={"loss": 0.5},
+            step=10,
+            extra={"custom_step": {"time": 1.5}},
+        )
+    )
+    h.close()
+    mock_wandb.init.return_value.log.assert_called_once_with(
+        {"loss": 0.5, "custom_step.time": 1.5}, step=10
+    )
+
+
+def test_media_nested_extra_logged_as_flat_axis(
+    mock_wandb: MagicMock,
+) -> None:
+    """Media events flatten nested extras too (no nested object key)."""
+    h = WandBHandler(project="p")
+    h.handle(
+        SimpleNamespace(
+            kind="image",
+            scope="global",
+            payload=np.zeros((4, 4, 3), dtype=np.uint8),
+            step=5,
+            extra={"name": "img", "custom_step": {"time": 2.0}},
+        )
+    )
+    h.close()
+    logged = mock_wandb.init.return_value.log.call_args.args[0]
+    assert logged["custom_step.time"] == 2.0
+    assert "custom_step" not in logged
+
+
 def test_step_none_bypasses_buffer_to_preserve_autoincrement(
     mock_wandb: MagicMock,
 ) -> None:


### PR DESCRIPTION
## Problem

Structured metadata logged alongside a metric — e.g.
`logger.scalar("loss", v, step=i, custom_step={"time": t})` — was merged into
`wandb.log` **as a nested dict**, which W&B stores as a multi-level *object*
that **cannot be selected as a chart x-axis** (the user could not plot metrics
against a physical-time/custom step).

**Verified empirically** by decoding the wandb datastore: a nested dict
`{"custom_step": {"time": t}}` is stored as a 2-element `nested_key`
(`custom_step`,`time`) = an object, whereas a flat `"custom_step.time"` key is a
1-element `nested_key` = a plain scalar metric. wandb does **not** split a flat
`.`-key back into levels, so `custom_step.time` stays selectable.

## Fix

`_flatten_logs` promotes nested-`Mapping` values to dotted scalar keys, applied
once in `_stage` (the single `run.log` choke point, so it covers
metric/media/histogram/vector_field). W&B media/other objects, scalars and
arrays pass through untouched. On a literal-vs-flattened key collision the last
value wins (pinned by tests + documented).

This is a **behavior change** (filed under `### Changed`): it applies to *any*
nested-dict value logged with a metric, not only the axis case — charts/queries
referencing an old nested key must switch to the dotted key.

## Verification

- New `examples/09_custom_step_axis.py` run offline → `custom_step.time` and
  `sim_time` land as **flat, plottable keys with zero nested objects**.
- Tests: `_flatten_logs` unit (nesting, non-mappings/identity, empty, **collision
  last-wins**) + handler tests (metric + media → flat key reaches `run.log`,
  nested object absent). **Full suite: 692 passed**, lint/pydoclint/basedpyright
  clean.
- `examples/04_wandb.py`: replaced an odd nested `custom_step={"custom_step": v}`
  with a flat scalar.

## Scope notes
- Kept the flatten **unconditional** (no opt-out flag / key whitelist) per the
  "nested objects shouldn't be logged" principle — not just the `custom_step`
  case.
- Did **not** add a single-run-per-scope mode (out of scope by request).
- `wandb.define_metric` is not used; the dotted scalar key is directly
  selectable as an axis (verified against the offline datastore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
