### PR TITLE
feat(wandb): accept a custom handler name in WandBHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- **`WandBHandler` accepts a custom handler name.** The event bus keys handlers
+  by name (one host bus per socket, shared across processes), so two
+  `WandBHandler`s could never coexist: the second one -- project and all -- was
+  silently dropped. Pass `WandBHandler(..., name="wandb.eval")` to attach
+  several W&B handlers side by side instead of mutating `handler.name` after
+  construction. The name defaults to `"wandb"` and now round-trips through
+  `to_dict()`/`from_dict()`; serialized payloads without it (older clients
+  attaching to a newer host) still rebuild with the default.
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -252,6 +252,7 @@ class WandBHandler:
         tags: Sequence[str] | None = None,
         reinit: Reinit = "create_new",
         wandb_init_kwargs: Mapping[str, Any] | None = None,
+        name: str = "wandb",
     ) -> None:
         """Initialize the W&B handler.
 
@@ -272,12 +273,16 @@ class WandBHandler:
                 {"finish_previous", "return_previous", "create_new", "default"}.
             wandb_init_kwargs: Additional keyword arguments forwarded to
                 ``wandb.init``.
+            name: Stable handler identifier. The event bus keys handlers
+                by it, so give each concurrently attached W&B handler a
+                distinct name.
 
         Raises:
             ValueError: If `reinit` is not a valid option, or if
                 `wandb_init_kwargs` contains invalid or handler-owned keys.
             TypeError: If `tags` is a `str` or contains non-string items.
         """
+        self.name = name
         self._logger = logging.getLogger(self.name)
         # Ensure that Goggles logs are not propagated to the root logger
         # to avoid duplicates
@@ -754,6 +759,7 @@ class WandBHandler:
         return {
             "cls": self.__class__.__name__,
             "data": {
+                "name": self.name,
                 "project": self._project,
                 "entity": self._entity,
                 "run_name": self._base_run_name,
@@ -769,6 +775,9 @@ class WandBHandler:
     def from_dict(cls, serialized: dict) -> Self:
         """De-serialize the handler from its dictionary representation.
 
+        Payloads serialized before the handler carried a name rebuild
+        with the class default.
+
         Args:
             serialized: The dictionary representation of the handler.
 
@@ -777,6 +786,7 @@ class WandBHandler:
         """
         data = serialized.get("data", serialized)
         return cls(
+            name=data.get("name", cls.name),
             project=data.get("project"),
             entity=data.get("entity"),
             run_name=data.get("run_name"),

--- a/tests/core/integrations/test_wandb.py
+++ b/tests/core/integrations/test_wandb.py
@@ -13,6 +13,7 @@ import wandb as _real_wandb
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.internal.datastore import DataStore
 
+import goggles as gg
 import goggles._core.integrations.wandb as wandb_module
 from goggles._core.integrations.wandb import WandBHandler
 
@@ -281,6 +282,95 @@ def test_wandb_init_kwargs_roundtrip_serialization(mock_wandb):
         reinit="create_new",
         save_code=True,
         settings={"code_dir": "."},
+    )
+
+
+def test_default_handler_name(mock_wandb):
+    """The handler keeps the default name when none is supplied.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    h = WandBHandler(project="proj")
+
+    assert h.name == "wandb", (
+        "Omitting 'name' must preserve the default handler name"
+    )
+
+
+def test_custom_handler_name(mock_wandb):
+    """The constructor stores a caller-provided handler name.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    h = WandBHandler(project="proj", name="wandb.eval")
+
+    assert h.name == "wandb.eval", (
+        "Constructor must store the custom handler name"
+    )
+
+
+def test_name_roundtrips_through_to_dict(mock_wandb):
+    """A custom name survives to_dict/from_dict serialization.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    h = WandBHandler(project="proj", name="wandb.eval")
+
+    serialized = h.to_dict()
+    restored = WandBHandler.from_dict(serialized)
+
+    assert serialized["data"]["name"] == "wandb.eval", (
+        "to_dict() must serialize the handler name"
+    )
+    assert restored.name == "wandb.eval", (
+        "from_dict() must restore the serialized handler name"
+    )
+
+
+def test_from_dict_without_name_uses_default(mock_wandb):
+    """Payloads predating the ``name`` field rebuild with the default.
+
+    Older clients attaching to a newer host ship no ``name`` key.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    restored = WandBHandler.from_dict({"project": "proj"})
+
+    assert restored.name == "wandb", (
+        "from_dict() must fall back to the default name when absent"
+    )
+
+
+def test_distinct_names_coexist_on_bus(mock_wandb):
+    """Two W&B handlers with distinct names both register on a bus.
+
+    The bus dedups handlers by name, so identically named handlers
+    would collapse into a single registration.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    bus = gg.EventBus()
+    train = WandBHandler(project="train", name="wandb.train")
+    evaluation = WandBHandler(project="eval", name="wandb.eval")
+
+    bus.attach([train.to_dict(), evaluation.to_dict()], scopes=["global"])
+
+    assert set(bus.handlers) == {"wandb.train", "wandb.eval"}, (
+        "Both distinctly named handlers must register on the bus"
+    )
+    assert bus.scopes["global"] == {"wandb.train", "wandb.eval"}, (
+        "Both handlers must be routed under the attached scope"
+    )
+    assert bus.handlers["wandb.train"]._project == "train", (
+        "Each registered handler must keep its own configuration"
+    )
+    assert bus.handlers["wandb.eval"]._project == "eval", (
+        "Each registered handler must keep its own configuration"
     )
 
 


### PR DESCRIPTION
Gives `WandBHandler` the same custom-name support its siblings already have, so several W&B handlers can coexist on one bus.

The event bus dedups handlers by `name` — globally, across every process on the socket — and `WandBHandler`'s name was a fixed class constant: `__init__` took no `name` parameter and `to_dict()`/`from_dict()` dropped the attribute. Attaching a second W&B handler silently collapsed it into the first (project and all). The only workaround was mutating `handler.name` post-construction, which still loses the name on serialization round-trips.

Closes #223.

## Changes
- `WandBHandler.__init__` accepts `name: str = "wandb"` (backward compatible), stored before the internal logger is created — mirroring `ConsoleHandler`/`LocalStorageHandler`. Appended positional-or-keyword to match how this constructor's recent parameters (`group`, `tags`, `wandb_init_kwargs`) were added.
- `to_dict()` serializes the name; `from_dict()` restores it and falls back to the class default when the key is absent (older clients attaching to a newer host).
- CHANGELOG entry under `[Unreleased]`.

## Testing
- 5 new tests in `tests/core/integrations/test_wandb.py` (existing `mock_wandb` fixture, no network): default name, custom name, serialization round-trip, missing-key fallback, and a bus-level test that two distinctly named W&B handlers both register and keep their own projects.
- Written TDD-style (red before the implementation).
- `uv run pytest`: 713 passed, 4 skipped (pre-existing environment skips).
- `uv run pre-commit run --files <changed>`: all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
