### PR TITLE
feat(api): export configure() and let it target a custom handler name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- **`gg.configure()` is public and can target a custom handler name.** The
+  idempotent console setup was reachable but absent from `goggles.__all__`
+  and undocumented; it is now part of the public surface and covered in the
+  README. Its new `name=` argument selects which console handler to replace
+  and attach (defaulting to the `ConsoleHandler` class default, so existing
+  callers are unaffected), so applications that namespace their handlers
+  (e.g. `"myapp.console"`) also get the last-call-wins semantics. (#224)
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ See also [Example 1](./examples/01_basic_run.py), which you can run after clonin
 uv run examples/01_basic_run.py
 ```
 
+### Idempotent console setup
+
+`gg.configure()` is a one-call shortcut for the console-only setup above, and the only handler-setup path where the **last call wins**: it detaches the console handler already attached to each target scope before attaching a fresh one, so the most recent options take effect. `gg.attach()` instead dedupes by handler name and silently keeps the first handler registered.
+
+```python
+import goggles as gg
+import logging
+
+# Attaches a ConsoleHandler on the "global" scope.
+gg.configure(enable_console=True, console_level=logging.INFO)
+
+# A later call wins: the handler above is replaced, not deduped.
+gg.configure(enable_console=True, console_level=logging.WARNING)
+
+# Namespace the handler when your application owns its own console.
+gg.configure(enable_console=True, name="myapp.console", scopes=["global"])
+```
+
+Prefer `configure()` over `attach()` when several call sites — or several processes sharing one host, see [Multi-process logging](#multi-process-logging-same-machine) — may set up the console and must converge on a single configuration regardless of arrival order; use `attach()` with explicit handler instances for everything else. Calling `gg.configure()` with no arguments is a no-op, so it is safe to invoke unconditionally during initialization.
+
 ### Experiment tracking with W&B
 
 ```python

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -46,7 +46,7 @@ public surface is (see [goggles/__init__.py](../../goggles/__init__.py)):
 - Event model: `Event`, `Kind`, `Metrics`, `Image`, `Video`,
   `Vector`, `VectorField`
 - Handlers: `ConsoleHandler`, `LocalStorageHandler`, `WandBHandler`
-- Bus management: `attach`, `detach`, `register_handler`
+- Bus management: `attach`, `configure`, `detach`, `register_handler`
 - Decorators: `timeit`, `trace_on_error`
 - Config: `PrettyConfig`, `load_configuration`, `save_configuration`
 - Shutdown: `GracefulShutdown`

--- a/goggles/__init__.py
+++ b/goggles/__init__.py
@@ -1029,6 +1029,7 @@ def configure(
     console_path_style: Literal["absolute", "relative"] = "relative",
     project_root: str | os.PathLike[str] | None = None,
     scopes: list[str] | None = None,
+    name: str | None = None,
 ) -> None:
     """One-call shortcut for the common "I just want a console logger" setup.
 
@@ -1047,8 +1048,12 @@ def configure(
 
     Calling ``configure(enable_console=True, ...)`` while a console handler
     is already attached to the target ``scopes`` re-attaches a fresh handler
-    with the new options (the old one is detached first), so the second call
-    wins instead of being silently deduped by name.
+    with the new options (the old one is detached first), so the **last call
+    wins** instead of being silently deduped by name. This makes it the
+    setup path of choice for multi-process applications, where several
+    processes race to configure the shared bus and must converge on one
+    console configuration regardless of arrival order -- unlike ``attach``,
+    which keeps the first handler registered under a given name.
 
     Args:
         enable_console: When True, attach a default ``ConsoleHandler``
@@ -1063,11 +1068,17 @@ def configure(
             to the current working directory.
         scopes: Scopes under which to attach the console handler.
             Defaults to ``["global"]``.
+        name: Identifier of the console handler to replace and attach,
+            for applications that namespace their handlers (e.g.
+            ``"myapp.console"``). Defaults to the ``ConsoleHandler``
+            class default.
     """
     if not enable_console:
         return
     if scopes is None:
         scopes = ["global"]
+    if name is None:
+        name = ConsoleHandler.name
 
     # Replace any existing console handler so a second `configure(...)` call
     # with new options actually takes effect (`attach()` dedupes by name and
@@ -1078,12 +1089,13 @@ def configure(
     # handler is not attached.
     for s in scopes:
         try:
-            detach(ConsoleHandler.name, s)
+            detach(name, s)
         except ValueError:
             # Not attached here (in-process bus); nothing to detach.
             pass
 
     handler = ConsoleHandler(
+        name=name,
         level=console_level,
         path_style=console_path_style,
         project_root=Path(project_root) if project_root is not None else None,
@@ -1230,6 +1242,7 @@ __all__ = [
     "Video",
     "WandBHandler",
     "attach",
+    "configure",
     "detach",
     "filters",
     "finish",

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -255,6 +255,69 @@ def test_configure_replaces_existing_console_handler() -> None:
         gg.finish()
 
 
+def test_configure_is_exported_from_package_root() -> None:
+    """configure() belongs to the documented public surface."""
+    assert "configure" in gg.__all__, (
+        "configure must be listed in goggles.__all__ to be public"
+    )
+    assert callable(getattr(gg, "configure", None)), (
+        "configure must be importable from the goggles package root"
+    )
+
+
+def test_configure_uses_custom_handler_name() -> None:
+    """configure(name=...) registers the console under that name."""
+    gg.finish()
+    try:
+        gg.configure(enable_console=True, name="app.console")
+        handlers = _bus_handlers()
+        assert "app.console" in handlers, (
+            "configure(name='app.console') must register the console "
+            f"handler under that name; saw {sorted(handlers)}"
+        )
+        assert gg.ConsoleHandler.name not in handlers, (
+            "A custom name must replace the class default, not be "
+            f"registered alongside '{gg.ConsoleHandler.name}'"
+        )
+    finally:
+        gg.finish()
+
+
+def test_configure_replaces_console_handler_with_custom_name() -> None:
+    """A second configure(name=...) call swaps that named handler."""
+    gg.finish()
+    try:
+        gg.configure(
+            enable_console=True,
+            name="app.console",
+            console_level=logging.INFO,
+        )
+        first = _bus_handlers()["app.console"]
+        gg.configure(
+            enable_console=True,
+            name="app.console",
+            console_level=logging.WARNING,
+        )
+        consoles = [
+            h
+            for h in _bus_handlers().values()
+            if isinstance(h, gg.ConsoleHandler)
+        ]
+        assert len(consoles) == 1, (
+            f"Reconfigure under a custom name must keep exactly one "
+            f"console handler; saw {len(consoles)}"
+        )
+        assert consoles[0] is not first, (
+            "Reconfigure must install a new ConsoleHandler instance "
+            "under the custom name"
+        )
+        assert consoles[0].level == logging.WARNING, (
+            f"The last configure() call must win (saw {consoles[0].level})"
+        )
+    finally:
+        gg.finish()
+
+
 def test_class_level_logger_does_not_hang_on_first_info() -> None:
     """Logger captured at class-body scope must not hang on first .info().
 

--- a/tests/core/test_dedicated_host.py
+++ b/tests/core/test_dedicated_host.py
@@ -315,6 +315,22 @@ def test_configure_replaces_console_under_dedicated_host(
         gg.finish(timeout=10.0)
 
 
+def test_configure_detaches_custom_console_name_under_dedicated_host(
+    default_host_socket: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The detach that makes the last configure() win must target the
+    # caller's handler name, not the class default -- otherwise an app that
+    # namespaces its console handler never replaces anything.
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(gg, "detach", lambda n, s: calls.append((n, s)))
+    try:
+        gg.configure(enable_console=True, name="app.console", scopes=["global"])
+        assert ("app.console", "global") in calls
+        assert (gg.ConsoleHandler.name, "global") not in calls
+    finally:
+        gg.finish(timeout=10.0)
+
+
 def test_falls_back_to_in_process_host_when_spawn_raises(
     default_host_socket: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Promotes `gg.configure()` — the library's only last-call-wins handler-setup path — to a usable public API.

`configure()` detaches the existing console handler for each target scope before attaching a fresh one, so repeated calls converge deterministically on the most recent options, unlike `gg.attach()`, which dedupes by handler name and silently keeps the first registration. That makes it the right setup primitive for multi-process applications sharing one host bus. But it was missing from `__all__`, absent from every doc page (its only mention was one CHANGELOG line), and hardwired to the class-default name `"goggles.console"` — an application that namespaces its console handler could not use it at all.

Closes #224.

## Changes
- `configure` added to `goggles.__all__`.
- New `name: str | None = None` parameter, resolved to the `ConsoleHandler` class default when unset (existing callers unchanged), used both in the detach loop and for the freshly attached handler.
- Docstring documents the parameter and the last-call-wins semantics; README gains an "Idempotent console setup" section (with an example and guidance on `configure()` vs `attach()`); `docs/guides/architecture.md` public-surface list now includes `configure`.
- CHANGELOG entry under `[Unreleased]`.

## Testing
- 3 new tests in `tests/core/test_api.py`: export/`__all__` membership; custom-name registration (class default absent); last-call-wins under a custom name.
- 1 new test in `tests/core/test_dedicated_host.py`: the over-the-wire detach targets the caller's name, not the class default.
- Written TDD-style (red before the implementation); the 4 pre-existing `configure()` tests are untouched and still pass, so default-name behavior is provably unchanged.
- `uv run pytest`: 712 passed, 4 skipped (pre-existing environment skips).
- `uv run pre-commit run --files <changed>`: all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
