### PR TITLE
fix(core): warn when attach() keeps the first handler on a name conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   construction. The name defaults to `"wandb"` and now round-trips through
   `to_dict()`/`from_dict()`; serialized payloads without it (older clients
   attaching to a newer host) still rebuild with the default.
+- **`attach()` now warns when a handler-name conflict silently drops a
+  configuration.** Handlers are keyed by `handler.name` and the first writer
+  wins, so attaching a second handler under a name that is already registered
+  discarded the newcomer -- its level, project, path and every other setting --
+  while still merging its scopes onto the *first* instance. That happened
+  silently, so a mistyped (or copy-pasted) name looked like it worked and then
+  logged with somebody else's configuration. The bus now emits a warning that
+  names the handler, lists only the config keys that actually differ (or
+  reports that the handler *class* differs), and states that the first
+  registration is kept. Re-attaching an identical configuration remains the
+  intended idempotent case and stays completely silent. The warning goes to
+  the host's stderr -- the same stream `ConsoleHandler` output and the other
+  host diagnostics already use -- so it is visible by default in the
+  dedicated-host setup (and follows `GOGGLES_HOST_LOG` when that is set).
+  Behavior is otherwise unchanged: the first handler still wins, scopes are
+  still merged, and no exception is raised.
 
 ## [0.3.0] - 2026-06-10
 

--- a/goggles/__init__.py
+++ b/goggles/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import gc
 import logging
 import os
+import sys
 import threading
 from collections import defaultdict
 from collections.abc import Callable
@@ -810,6 +811,108 @@ class Handler(Protocol):
 # ---------------------------------------------------------------------------
 # EventBus and run management
 # ---------------------------------------------------------------------------
+
+# Longest config value inlined in a conflict warning; longer ones are elided.
+_MAX_REPORTED_VALUE_CHARS = 40
+
+_UNSET = object()
+
+
+def _short_repr(value: object) -> str:
+    """Render a handler config value compactly.
+
+    Args:
+        value: The value to render.
+
+    Returns:
+        The value's repr, or a placeholder when the key is absent from the
+        config or its repr is too long to inline in a warning.
+
+    """
+    if value is _UNSET:
+        text = "<unset>"
+    else:
+        text = repr(value)
+        if len(text) > _MAX_REPORTED_VALUE_CHARS:
+            text = "<omitted>"
+    return text
+
+
+def _differing_config_keys(kept: dict, ignored: dict) -> list[str]:
+    """List the keys whose values differ between two handler configs.
+
+    Args:
+        kept: Config data of the handler that stays registered.
+        ignored: Config data of the handler that is dropped.
+
+    Returns:
+        One short description per differing key.
+
+    """
+    differences = []
+    for key in sorted(set(kept) | set(ignored)):
+        old = kept.get(key, _UNSET)
+        new = ignored.get(key, _UNSET)
+        if old != new:
+            differences.append(
+                f"{key} (kept {_short_repr(old)}, ignored {_short_repr(new)})"
+            )
+    return differences
+
+
+def _describe_handler_conflict(kept: dict, ignored: dict) -> str | None:
+    """Describe how a dropped handler differs from the registered one.
+
+    Args:
+        kept: Serialized form of the already-registered handler.
+        ignored: Serialized handler that is about to be dropped.
+
+    Returns:
+        A short description of the difference, or None when the two
+        serialized handlers are identical.
+
+    """
+    description = None
+    if kept.get("cls") != ignored.get("cls"):
+        description = (
+            f"handler class differs (kept {kept.get('cls')!r}, "
+            f"ignored {ignored.get('cls')!r})"
+        )
+    else:
+        keys = _differing_config_keys(
+            kept.get("data") or {}, ignored.get("data") or {}
+        )
+        if keys:
+            description = "config differs in " + "; ".join(keys)
+    return description
+
+
+def _warn_handler_conflict(registered: Handler, incoming: dict) -> None:
+    """Warn on stderr that a differing same-named handler was dropped.
+
+    Stays silent when the incoming handler serializes exactly like the
+    registered one, which is the intended idempotent re-attach.
+
+    The bus usually runs in the dedicated host process, which inherits the
+    application's stderr (or ``GOGGLES_HOST_LOG``), so stderr is where the
+    host's other diagnostics already surface.
+
+    Args:
+        registered: The handler already registered under this name.
+        incoming: Serialized handler that ``attach`` is dropping.
+
+    """
+    difference = _describe_handler_conflict(registered.to_dict(), incoming)
+    if difference is not None:
+        print(
+            f"goggles: attach() name conflict for handler "
+            f"'{registered.name}': {difference}. Keeping the first "
+            f"registration; the new configuration is ignored.",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
 class EventBus:
     """Process-wide event router.
 
@@ -884,6 +987,11 @@ class EventBus:
     def attach(self, handlers: list[dict], scopes: list[str]) -> None:
         """Attach handler(s) under the given scopes.
 
+        Handlers are keyed by name, first writer wins: attaching a differing
+        configuration under an already-registered name keeps the first
+        handler and warns on stderr, while still merging the given scopes.
+        Re-attaching an identical configuration is silent.
+
         Args:
             handlers:
                 The serialized handlers to attach to the scopes.
@@ -894,17 +1002,19 @@ class EventBus:
             handler_class = _get_handler_class(handler_dict["cls"])
             handler = handler_class.from_dict(handler_dict["data"])
             with self._lock:
-                newly_added = handler.name not in self.handlers
-                if newly_added:
+                registered = self.handlers.get(handler.name)
+                if registered is None:
                     self.handlers[handler.name] = handler
                 for scope in scopes:
                     if scope not in self.scopes:
                         self.scopes[scope] = set()
                     self.scopes[scope].add(handler.name)
-            if newly_added:
+            if registered is None:
                 # Call handler.open() outside the lock: it may do I/O
                 # (e.g. open a wandb run) and must not block readers.
                 handler.open()
+            else:
+                _warn_handler_conflict(registered, handler_dict)
 
     def detach(self, handler_name: str, scope: str) -> None:
         """Detach a handler from the given scope.

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -408,6 +408,149 @@ def test_eventbus_emit_ignores_unknown_scope():
 
 
 # ---------------------------------------------------------------------
+# attach() handler-name conflicts
+# ---------------------------------------------------------------------
+
+
+class ConflictHandler:
+    """Handler whose serialized config the test controls key by key."""
+
+    name: str = "conflict"
+    capabilities: ClassVar[frozenset[gg.Kind]] = frozenset({"log"})
+
+    def __init__(self, name="conflict", level=logging.INFO, path="logs"):
+        self.name = name
+        self.level = level
+        self.path = path
+
+    def can_handle(self, kind):
+        return True
+
+    def handle(self, event):
+        pass
+
+    def open(self):
+        pass
+
+    def close(self):
+        pass
+
+    def to_dict(self):
+        return {
+            "cls": type(self).__name__,
+            "data": {
+                "name": self.name,
+                "level": self.level,
+                "path": self.path,
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, serialized):
+        return cls(**serialized)
+
+
+class OtherConflictHandler(ConflictHandler):
+    """A second handler class serializing under the same config keys."""
+
+
+def _stderr_lines(capsys) -> list[str]:
+    """Non-empty stderr lines captured so far."""
+    return [line for line in capsys.readouterr().err.splitlines() if line]
+
+
+def test_attach_identical_config_twice_is_silent(capsys) -> None:
+    """Re-attaching the very same config is the idempotent case."""
+    gg.register_handler(ConflictHandler)
+    bus = gg.EventBus()
+    handler = ConflictHandler(name="dup", level=logging.INFO)
+
+    bus.attach([handler.to_dict()], scopes=["a"])
+    bus.attach([handler.to_dict()], scopes=["a"])
+
+    assert _stderr_lines(capsys) == [], (
+        "Re-attaching an identical handler config must stay silent"
+    )
+    assert list(bus.handlers) == ["dup"], (
+        "An identical re-attach must not register a second handler"
+    )
+
+
+def test_attach_conflicting_level_warns_and_keeps_first(capsys) -> None:
+    """A differing config under a known name warns and changes nothing."""
+    gg.register_handler(ConflictHandler)
+    bus = gg.EventBus()
+    first = ConflictHandler(name="dup", level=logging.INFO)
+    second = ConflictHandler(name="dup", level=logging.DEBUG)
+
+    bus.attach([first.to_dict()], scopes=["a"])
+    bus.attach([second.to_dict()], scopes=["b"])
+
+    warnings = _stderr_lines(capsys)
+    assert len(warnings) == 1, (
+        f"Expected exactly one conflict warning, got {warnings}"
+    )
+    assert "dup" in warnings[0], "The warning must name the handler"
+    assert "level" in warnings[0], (
+        "The warning must list the config key that differs"
+    )
+    assert "path" not in warnings[0], (
+        "The warning must not list config keys that are identical"
+    )
+    assert "first" in warnings[0], (
+        "The warning must say the first registration is kept"
+    )
+    assert cast(Any, bus.handlers["dup"]).level == logging.INFO, (
+        "The first registration must stay in effect"
+    )
+    assert bus.scopes["b"] == {"dup"}, (
+        "The second attach's scopes must still be merged"
+    )
+
+
+def test_attach_different_names_same_scope_does_not_warn(capsys) -> None:
+    """Distinct names sharing a scope are not a conflict."""
+    gg.register_handler(ConflictHandler)
+    bus = gg.EventBus()
+    first = ConflictHandler(name="one", level=logging.INFO)
+    second = ConflictHandler(name="two", level=logging.DEBUG)
+
+    bus.attach([first.to_dict(), second.to_dict()], scopes=["a"])
+
+    assert _stderr_lines(capsys) == [], "Different handler names must not warn"
+    assert set(bus.handlers) == {"one", "two"}, (
+        "Both handlers should be registered under their own names"
+    )
+    assert bus.scopes["a"] == {"one", "two"}, (
+        "Both handlers should be routed under the shared scope"
+    )
+
+
+def test_attach_conflicting_class_reports_the_class(capsys) -> None:
+    """A same-named handler of another class reports the class itself."""
+    gg.register_handler(ConflictHandler)
+    gg.register_handler(OtherConflictHandler)
+    bus = gg.EventBus()
+    first = ConflictHandler(name="dup")
+    second = OtherConflictHandler(name="dup")
+
+    bus.attach([first.to_dict()], scopes=["a"])
+    bus.attach([second.to_dict()], scopes=["a"])
+
+    warnings = _stderr_lines(capsys)
+    assert len(warnings) == 1, (
+        f"Expected exactly one conflict warning, got {warnings}"
+    )
+    assert "dup" in warnings[0], "The warning must name the handler"
+    assert "class" in warnings[0], (
+        "A differing handler class must be reported as such"
+    )
+    assert type(bus.handlers["dup"]) is ConflictHandler, (
+        "The first registration must stay in effect"
+    )
+
+
+# ---------------------------------------------------------------------
 # LocalStorageHandler I/O
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
Makes the bus's silent first-writer-wins handler dedup loud when it actually drops a configuration.

`EventBus.attach()` keys handlers by `name` alone — globally, one host bus per socket shared by every process. Attaching a second handler under a registered name fully deserialized the newcomer and then discarded it (level, project, path, everything) while still merging its scopes onto the *first* instance — with no warning, no log line, and no return value. Both failure modes of the naming contract were therefore invisible: different names for one destination duplicate output; one name with divergent options picks an arbitrary winner decided by process start order. A downstream project (flowgames) hit both in production; this warning would have surfaced each on first run.

Closes #222.

## Changes
- `EventBus.attach()` now captures the already-registered handler and, when the incoming serialized config differs, emits a single warning naming the handler, listing only the config keys that actually differ as `key (kept X, ignored Y)` (or reporting that the handler *class* differs), and stating that the first registration is kept. Values longer than 40 chars render as `<omitted>`, so large configs are never dumped.
- Re-attaching an identical config is the intended idempotent case and stays completely silent. Behavior is otherwise unchanged: first handler still wins, scopes still merge, no exception raised.
- CHANGELOG entry under `[Unreleased]`.

## Warning channel — verified empirically
The warning goes to the host process's stderr (`goggles: ` prefix, flushed), matching `host.py`'s existing diagnostics. A bare `logging.getLogger("goggles").warning(...)` is invisible by default: the import-time `NullHandler` counts as a found handler in `Logger.callHandlers`, which suppresses `logging.lastResort` — verified with a clean-environment run, which also confirmed the existing `_log.warning(...)` host diagnostics never reach the terminal. Stderr is inherited from the spawning process in the dedicated-host setup and follows `GOGGLES_HOST_LOG` when set; the end-to-end warning was confirmed in a real dedicated-host run.

## Testing
- 4 new tests in `tests/core/test_api.py` against a fresh `EventBus` with a purpose-built handler and `capsys`: identical re-attach silent; differing level → exactly one warning (names handler, lists `level`, omits the identical `path`, says "first"), first config still in effect, second call's scopes still merged; different names → both register, no warning; differing class → class reported.
- Written TDD-style (red before the implementation).
- `uv run pytest`: 712 passed, 4 skipped (pre-existing environment skips).
- `uv run pre-commit run --files <changed>`: all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
