### PR TITLE
docs: document handler naming as the dedup key and unify example names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,31 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   construction. The name defaults to `"wandb"` and now round-trips through
   `to_dict()`/`from_dict()`; serialized payloads without it (older clients
   attaching to a newer host) still rebuild with the default.
+- **Handler naming is documented as the bus-wide dedup key.** A new
+  "Handler naming" section in the README (cross-referenced from
+  [docs/guides/architecture.md](docs/guides/architecture.md) §3) spells out
+  what was previously only implicit: `attach` keys handlers by `name` on the
+  single bus shared by every process on a socket, so a name is global
+  application state -- one name per output destination, defined once as a
+  module-level constant and shared across entry points. On a conflict the
+  first registration wins silently and only the later handler's scopes are
+  merged onto it.
+
+### Fixed
+
+- **README multi-scope example routed to the wrong handlers.** The snippet
+  called `logger_scope2.bind(scope="scope2")` without assigning the result --
+  `bind` returns a new logger and does not mutate the receiver -- so the
+  logger kept its original scope and its "logged only by handler2" line
+  reached *both* handlers. The neighbouring namespace line, emitted on a
+  scope with no attached handler, reached *none*. Both now do what the
+  surrounding text claims.
+- **Examples no longer share handler names across files.**
+  `examples/01_basic_run.py` and `examples/102_decorators.py` both attached
+  `"examples.basic.console"` but at different levels, so running both in one
+  session silently kept whichever attached first. Every example now declares
+  its handler names as module-level constants under a single
+  `examples.<topic>.<destination>` scheme.
 
 ## [0.3.0] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,31 @@ See also [Example 1](./examples/01_basic_run.py), which you can run after clonin
 uv run examples/01_basic_run.py
 ```
 
+### Handler naming
+
+Every handler carries a `name`, and the event bus identifies it by that name alone. There is a single bus per `GOGGLES_SOCKET`, shared by every process that connects to it, so **handler names are global to your whole application** — not per module, not per process. Give each output destination exactly one name, and define those names once as module-level constants that every entry point imports, rather than retyping a string at each `attach` call site.
+
+```python
+# myapp/logging_setup.py -- one definition, imported everywhere
+CONSOLE_HANDLER_NAME = "myapp.console"
+STORAGE_HANDLER_NAME = "myapp.storage"
+```
+
+```python
+# any entry point: trainer, evaluator, dataloader worker, ...
+from myapp.logging_setup import CONSOLE_HANDLER_NAME
+
+gg.attach(
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
+    scopes=["global"],
+)
+```
+
+> [!WARNING]
+> **On a name conflict the first registration wins, silently.** Attaching a handler under a name the bus already knows neither replaces it nor raises: the later instance — with its own level, path, project, ... — is ignored, and only its `scopes` are merged onto the handler already registered under that name. So two names for one destination duplicate that destination's output, while one name for two different configurations keeps whichever process attached first.
+
+Names and scopes are independent: the name decides *which handler instance* the bus keeps, the scopes decide *which events reach it*. Re-attaching the same name under new scopes is therefore the supported way to widen an existing handler's routing.
+
 ### Idempotent console setup
 
 `gg.configure()` is a one-call shortcut for the console-only setup above, and the only handler-setup path where the **last call wins**: it detaches the console handler already attached to each target scope before attaching a fresh one, so the most recent options take effect. `gg.attach()` instead dedupes by handler name and silently keeps the first handler registered.
@@ -251,18 +276,24 @@ Within the same run, we may have logs that belong to different scopes. An exampl
 #### Usage
 
 ```python
-# In this example, we set up a handlers associated
-# to different scopes.
-handler1 = gg.ConsoleHandler(name="examples.basic.console.1", level=logging.INFO)
+# In this example, we set up a handlers associated to different scopes.
+# Handler names are bus-wide identities, so we define them once
+# (see "Handler naming" above).
+HANDLER1_NAME = "examples.multi_scope.console.1"
+HANDLER2_NAME = "examples.multi_scope.console.2"
+
+handler1 = gg.ConsoleHandler(name=HANDLER1_NAME, level=logging.INFO)
 gg.attach(handler1, scopes=["global", "scope1"])
 
-handler2 = gg.ConsoleHandler(name="examples.basic.console.2", level=logging.INFO)
+handler2 = gg.ConsoleHandler(name=HANDLER2_NAME, level=logging.INFO)
 gg.attach(handler2, scopes=["global", "scope2"])
 
 # We need to get separate loggers for each scope
 logger_scope1 = gg.get_logger("examples.basic.scope1", scope="scope1")
 logger_scope2 = gg.get_logger("examples.basic.scope2")
-logger_scope2.bind(scope="scope2")  # You can also bind the scope after creation
+# `bind` returns a new logger, it does not mutate the receiver: the
+# result has to be assigned for the new scope to take effect.
+logger_scope2 = logger_scope2.bind(scope="scope2")
 logger_global = gg.get_logger("examples.basic.global", scope="global")
 
 # Now we can log messages to different scopes, so that only the interested
@@ -271,9 +302,11 @@ logger_scope1.info(f"This will be logged only by {handler1.name}")
 logger_scope2.info(f"This will be logged only by {handler2.name}")
 logger_global.info("This will be logged by both handlers.")
 
-# The same result can be achieved using namespaces,
-# which are indicated by dot notation.
-logger_namespace = gg.get_logger("examples.basic.namespace", scope="namespace")
+# Scopes are hierarchical, with the levels indicated by dot notation, so a
+# child scope also reaches the handlers attached to its parent.
+logger_namespace = gg.get_logger(
+    "examples.basic.namespace", scope="global.namespace"
+)
 logger_namespace.info("This will be logged by both handlers.")
 
 gg.finish()

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -120,6 +120,17 @@ Adding a new handler: subclass an existing handler or implement the
 `register_handler()` so it can be serialized for transport across the
 bus.
 
+#### Handler names are the bus-wide dedup key
+
+`EventBus.attach` keys its handler registry by `handler.name`, and there
+is one bus per socket shared by every process on it (§4). A name is
+therefore global application state, not a local label: the first
+registration under a name wins, later ones are dropped silently and only
+their scopes merge onto the incumbent. Use one name per output
+destination and define it once as a module-level constant shared across
+entry points. See [Handler naming](../../README.md#handler-naming) in
+the README for the user-facing guidance.
+
 ### 4. Transport (`_core/transport/`)
 
 See [transport.md](transport.md) for the package layout (frames,

--- a/examples/01_basic_run.py
+++ b/examples/01_basic_run.py
@@ -1,9 +1,14 @@
 import goggles as gg
 
+# A handler name is the bus-wide identity of a destination, so define it
+# once here rather than retyping the string at every attach call site.
+CONSOLE_HANDLER_NAME = "examples.basic.console"
+DEBUG_CONSOLE_HANDLER_NAME = "examples.basic.debug_console"
+
 # In this basic example, we set up a logger that outputs to the console.
 logger = gg.get_logger("examples.basic")
 gg.attach(
-    gg.ConsoleHandler(name="examples.basic.console", level=gg.INFO),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
     scopes=["global"],
 )
 
@@ -18,7 +23,7 @@ logger.critical("This is critical!")
 
 # Lowering handler log level makes debug messages visible.
 gg.attach(
-    gg.ConsoleHandler(name="examples.basic.debug_console", level=gg.DEBUG),
+    gg.ConsoleHandler(name=DEBUG_CONSOLE_HANDLER_NAME, level=gg.DEBUG),
     scopes=["global"],
 )
 

--- a/examples/02_multi_scope.py
+++ b/examples/02_multi_scope.py
@@ -1,11 +1,16 @@
 import goggles as gg
 
+# Each console handler needs its own bus-wide name; define them once here.
+HANDLER1_NAME = "examples.multi_scope.console.1"
+HANDLER2_NAME = "examples.multi_scope.console.2"
+HANDLER3_NAME = "examples.multi_scope.console.3"
+
 # In this example, we set up a handlers associated
 # to different scopes.
-handler1 = gg.ConsoleHandler(name="examples.basic.console.1", level=gg.INFO)
+handler1 = gg.ConsoleHandler(name=HANDLER1_NAME, level=gg.INFO)
 gg.attach(handler1, scopes=["global", "namespace.scope1"])
 
-handler2 = gg.ConsoleHandler(name="examples.basic.console.2", level=gg.INFO)
+handler2 = gg.ConsoleHandler(name=HANDLER2_NAME, level=gg.INFO)
 gg.attach(handler2, scopes=["global", "namespace.scope2"])
 
 # We need to get separate loggers for each scope
@@ -24,7 +29,7 @@ logger_global.info("This will be logged by both handlers.")
 
 # The same result can be achieved using namespaces,
 # which are indicated by dot notation.
-handler3 = gg.ConsoleHandler(name="examples.basic.console.3", level=gg.INFO)
+handler3 = gg.ConsoleHandler(name=HANDLER3_NAME, level=gg.INFO)
 gg.attach(handler3, scopes=["namespace"])
 logger_scope1.info(
     f"This will be logged by {handler1.name} and {handler3.name}"

--- a/examples/03_local_storage.py
+++ b/examples/03_local_storage.py
@@ -4,6 +4,10 @@ import numpy as np
 
 import goggles as gg
 
+# One name per output destination, defined once for the whole example.
+STORAGE_HANDLER_NAME = "examples.jsonl.storage"
+CONSOLE_HANDLER_NAME = "examples.jsonl.console"
+
 # In this example, we set up a logger that stores events
 # in a structured directory:
 # - examples/logs/log.jsonl: Main JSONL log file with all events
@@ -20,11 +24,11 @@ logger = gg.get_logger("examples.jsonl", with_metrics=True)
 gg.attach(
     gg.LocalStorageHandler(
         path=Path("examples/logs"),
-        name="examples.jsonl",
+        name=STORAGE_HANDLER_NAME,
     )
 )
 gg.attach(
-    gg.ConsoleHandler(name="examples.jsonl.console", level=gg.INFO),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
 )
 
 print("=== Goggles Local Storage Handler Example ===")

--- a/examples/06_custom_handler.py
+++ b/examples/06_custom_handler.py
@@ -1,5 +1,7 @@
 import goggles as gg
 
+CONSOLE_HANDLER_NAME = "examples.custom.console"
+
 
 class CustomConsoleHandler(gg.ConsoleHandler):
     """A custom console handler that adds a prefix to each log message."""
@@ -21,7 +23,7 @@ logger = gg.get_logger("examples.custom_handler")
 
 
 gg.attach(
-    CustomConsoleHandler(name="examples.custom.console", level=gg.INFO),
+    CustomConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
     scopes=["global"],
 )
 # Because the logging level is set to INFO, the debug message will not be shown.

--- a/examples/07_library_vs_app.py
+++ b/examples/07_library_vs_app.py
@@ -38,6 +38,12 @@ def library_work():
 
 
 # ------------------ Application code (what an app would do) ------------------
+# The app owns the handler names: one per output destination, declared once
+# here so every entry point attaches under the very same identity.
+CONSOLE_HANDLER_NAME = "examples.app.console"
+STORAGE_HANDLER_NAME = "examples.app.storage"
+
+
 def setup_logging(project_root: Path | str = "examples/logs") -> None:
     """Set up handlers for the application.
 
@@ -56,12 +62,15 @@ def setup_logging(project_root: Path | str = "examples/logs") -> None:
     project_root = Path(project_root)
     # Console for general messages (global)
     gg.attach(
-        gg.ConsoleHandler(name="app.console", level=gg.INFO), scopes=["global"]
+        gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
+        scopes=["global"],
     )
 
     # Local storage for library events (stored under examples/logs/library)
     gg.attach(
-        gg.LocalStorageHandler(path=project_root / "library", name="app.local"),
+        gg.LocalStorageHandler(
+            path=project_root / "library", name=STORAGE_HANDLER_NAME
+        ),
         scopes=[LIBRARY_SCOPE],
     )
 

--- a/examples/08_dedicated_host.py
+++ b/examples/08_dedicated_host.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import goggles as gg
 
+STORAGE_HANDLER_NAME = "examples.dedicated_host.storage"
+
 
 def main() -> None:
     """Log a few events; the handler runs in the dedicated host subprocess."""
@@ -31,7 +33,7 @@ def main() -> None:
 
     gg.attach(
         gg.LocalStorageHandler(
-            path=Path("examples/logs/dedicated"), name="local"
+            path=Path("examples/logs/dedicated"), name=STORAGE_HANDLER_NAME
         ),
         scopes=["global"],
     )

--- a/examples/100_interrupt.py
+++ b/examples/100_interrupt.py
@@ -7,12 +7,12 @@ from types import FrameType
 import goggles as gg
 from goggles._core.integrations import ConsoleHandler
 
+CONSOLE_HANDLER_NAME = "examples.interrupt.console"
+
 # Instantiate a TextLogger (No metrics)
 logger = gg.get_logger("examples.interrupt")
 
-gg.attach(
-    ConsoleHandler(name="examples.interrupt.info", level=gg.INFO), ["global"]
-)
+gg.attach(ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO), ["global"])
 
 _prev_sigint_handler = signal.getsignal(signal.SIGINT)
 

--- a/examples/102_decorators.py
+++ b/examples/102_decorators.py
@@ -6,9 +6,14 @@ untyped. You can safely ignore these warnings with # type: ignore[misc].
 
 import goggles as gg
 
+# Handler names are bus-wide, so this example owns its own name instead of
+# reusing the one from `01_basic_run.py` (which attaches at INFO: sharing a
+# name would silently keep whichever of the two attached first).
+CONSOLE_HANDLER_NAME = "examples.decorators.console"
+
 gg.attach(
     gg.ConsoleHandler(
-        name="examples.basic.console", level=gg.DEBUG
+        name=CONSOLE_HANDLER_NAME, level=gg.DEBUG
     ),  # Changed to DEBUG to see timeit output
     scopes=["global"],
 )

--- a/examples/104_filters.py
+++ b/examples/104_filters.py
@@ -33,9 +33,11 @@ from goggles.filters import (
     create_concat_filter,
 )
 
+CONSOLE_HANDLER_NAME = "examples.filters.console"
+
 # Set up logging
 gg.attach(
-    gg.ConsoleHandler(name="examples.filters.console", level=gg.INFO),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
     scopes=["global"],
 )
 logger = gg.get_logger("examples.filters")

--- a/examples/105_benchmark.py
+++ b/examples/105_benchmark.py
@@ -106,6 +106,8 @@ os.environ["PYTHONPATH"] = (
 
 from _benchmark_handlers import DeliveryCounter  # noqa: E402
 
+CONSOLE_HANDLER_NAME = "examples.benchmark.console"
+
 # ``_logger`` is populated inside the per-preset subprocess (see
 # ``_run_benchmark``). Creating it at module import would make the parent
 # Hydra process bind the goggles socket, which subsequently spawned
@@ -516,7 +518,7 @@ def _run_benchmark(cfg: DictConfig) -> None:
 
     gg.attach(
         gg.ConsoleHandler(
-            name="goggles.benchmark.console",
+            name=CONSOLE_HANDLER_NAME,
             level=gg.INFO,
         ),
         scopes=["goggles.benchmark"],

--- a/examples/106_log_levels.py
+++ b/examples/106_log_levels.py
@@ -2,11 +2,13 @@ import logging
 
 import goggles as gg
 
+CONSOLE_HANDLER_NAME = "examples.levels.console"
+
 # A console handler that lets DEBUG and above through. Per-logger level
 # filtering happens *before* the handler, so the handler stays permissive
 # and each logger decides what it emits.
 gg.attach(
-    gg.ConsoleHandler(name="examples.levels.console", level=gg.DEBUG),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.DEBUG),
     scopes=["global"],
 )
 

--- a/examples/107_push_images.py
+++ b/examples/107_push_images.py
@@ -11,12 +11,15 @@ import goggles as gg
 # channel axis in {1, 3, 4}.
 
 LOG_DIR = Path("examples/logs/107_push")
+STORAGE_HANDLER_NAME = "examples.push.storage"
+CONSOLE_HANDLER_NAME = "examples.push.console"
+
 logger = gg.get_logger("examples.push", with_metrics=True)
 gg.attach(
-    gg.LocalStorageHandler(path=LOG_DIR, name="examples.push"),
+    gg.LocalStorageHandler(path=LOG_DIR, name=STORAGE_HANDLER_NAME),
 )
 gg.attach(
-    gg.ConsoleHandler(name="examples.push.console", level=gg.INFO),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
 )
 
 print(f"=== writing logs to {LOG_DIR} ===\n")

--- a/examples/108_class_level_logger.py
+++ b/examples/108_class_level_logger.py
@@ -16,6 +16,8 @@ handlers the application installs later. No re-bind is needed.
 
 import goggles as gg
 
+CONSOLE_HANDLER_NAME = "examples.class_level.console"
+
 
 class Worker:
     """A class that holds its logger as a class attribute.
@@ -60,7 +62,7 @@ w2 = Worker("beta")
 # Application setup happens *after* Worker has been imported and its
 # class-level logger has already been built.
 gg.attach(
-    gg.ConsoleHandler(name="examples.class_level.console", level=gg.INFO),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
     scopes=["global"],
 )
 

--- a/examples/_benchmark_handlers.py
+++ b/examples/_benchmark_handlers.py
@@ -18,6 +18,8 @@ from typing import ClassVar
 import goggles as gg
 from goggles import Event, Kind
 
+COUNTER_HANDLER_NAME = "examples.benchmark.counter"
+
 
 class DeliveryCounter:
     """Counts events delivered to the host, persisting totals to a file.
@@ -32,7 +34,7 @@ class DeliveryCounter:
         capabilities: Event kinds this handler claims to handle.
     """
 
-    name = "goggles.benchmark.counter"
+    name = COUNTER_HANDLER_NAME
     capabilities: ClassVar[frozenset[Kind]] = frozenset(
         {
             "log",


### PR DESCRIPTION
Documents the handler-naming contract and makes goggles' own docs and examples follow it.

The handler `name` is the bus-wide dedup key — one host bus per socket, shared by every process — yet no document said so, no naming convention existed, and docs/examples scattered 20+ distinct hardcoded handler-name strings. Two examples collided outright: `01_basic_run.py` and `102_decorators.py` both attached `"examples.basic.console"` at different levels, silently keeping whichever ran first. Downstream projects copy this style and hit duplicated console output or silently dropped handlers in multi-process apps.

Closes #225.

## Changes
- **README "Handler naming" section** (after Basic usage): names are global application state; one name per output destination; define names once as module-level constants shared across entry points; on conflict the first registration wins and later scopes merge onto the incumbent; names route *which handler*, scopes route *which events*.
- **`docs/guides/architecture.md`**: short "Handler names are the bus-wide dedup key" paragraph in the Handlers section, cross-referencing the README.
- **README multi-scope example fixed — its claims were wrong two ways**: it discarded the logger returned by `bind` (non-mutating), so the "only by handler2" line actually printed on *both* handlers; and it used `scope="namespace"`, which matches no attached scope, so the "both handlers" line printed on *none*. Now assigns the bound logger and uses `"global.namespace"`. Verified by running the snippet before/after: output is now 1 / 2 / 2 exactly as the prose claims.
- **13 examples + 1 helper**: every inline handler name hoisted to a module-level `UPPER_SNAKE_CASE` constant, unified on `examples.<topic>.<destination>`, all 20 names now unique. Renames only, no logic changes.
- CHANGELOG entries under `[Unreleased]`.

## Testing
- Ran all 13 touched runnable examples green on isolated sockets (01, 02, 03, 06, 07, 08, 100 via SIGINT, 102, 104–108; 105 with `wandb.enabled=false`; 07 with `WANDB_MODE=offline` to avoid creating real runs). `_benchmark_handlers.py` exercised through 105 end-to-end, proving the renamed handler reconstructs in the host subprocess.
- Verified the documented dedup semantics empirically (INFO handler survives a DEBUG re-attach under the same name; second attach's scope still merges).
- `uv run pytest`: 708 passed, 4 skipped (pre-existing environment skips). `uv run pre-commit run --files <17 changed>`: all hooks pass.

## Notes for the reviewer
- If #228 (attach conflict warning) merges, the two "silently" phrasings in the new README section deserve a one-word touch-up ("silently" → "with only a stderr warning"); left as-is here since the branches are independent.
- Pre-existing issues found while validating, out of scope, happy to file: (1) `examples/06_custom_handler.py` prints nothing under the default dedicated host (host can't reconstruct the custom class without `GOGGLES_HOST_IMPORTS`) — reproduced on unmodified HEAD; (2) nondeterministic `LocalStorageHandler` shutdown race in 07 (`AttributeError: '_fp'`), also on unmodified HEAD; (3) `examples/02_multi_scope.py` still contains a harmless discarded-`bind` no-op (the logger already has that scope) — left per the renames-only constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
