### PR TITLE
ci(commitlint): exempt the non-conventional Copilot squash titles

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -11,6 +11,20 @@
 // `Agent-Logs-Url:` URLs) that legitimately exceed 100 characters,
 // and the workflow re-lints merged history on every downstream push,
 // so a single long trailer would otherwise poison future merges.
+
+// Squash-merge subjects already in main/dev history that predate
+// conventional-title enforcement for bot PRs (#229, #230). History
+// cannot be rewritten, and the workflow re-lints history on every
+// push (force-pushes lint deep history), so these exact first lines
+// are permanently exempted. Exact match only: new commits stay fully
+// linted. When squash-merging a PR, the PR title becomes the commit
+// subject -- keep it conventional so this list never grows.
+const LEGACY_SQUASH_SUBJECTS = [
+    'Pin Pillow to patched version to unblock pip-audit workflow (#229)',
+    'Resolve pip-audit CI failure by upgrading Pillow to a patched' +
+        ' version (#230)',
+];
+
 export default {
     extends: ['@commitlint/config-conventional'],
     ignores: [
@@ -18,6 +32,8 @@ export default {
             /^Merge (pull request|branch|remote-tracking branch) /.test(
                 message,
             ),
+        (message) =>
+            LEGACY_SQUASH_SUBJECTS.includes(message.split('\n')[0]),
     ],
     rules: {
         'body-max-line-length': [0],


### PR DESCRIPTION
Unbreaks `Commit style validation` for the whole repository.

The squash-merge commits of #229 / #230 have titles without a conventional-commit type (`Pin Pillow to patched version to unblock pip-audit workflow (#229)`, `Resolve pip-audit CI failure by upgrading Pillow to a patched version (#230)`), and the commit-lint workflow re-lints history on every push — force-pushes lint deep history. Since those two commits are now a permanent part of `main`/`dev`, every downstream push fails: `main`'s own runs at 12:12/12:14 UTC today, the `dev` fast-forward at 12:17, and all four rebased feature branches (#226–#228, #231) — each with the identical `subject may not be empty` / `type may not be empty` errors on exactly those two commits.

Closes #232.

## Changes
- `commitlint.config.mjs`: a documented `LEGACY_SQUASH_SUBJECTS` list with the two exact first lines, wired into `ignores` — the same pattern the config already uses for GitHub-generated merge commits. Exact-match only: a *new* non-conventional subject still fails, so linting is not loosened going forward.
- Reminder in the comment: when squash-merging, the PR title becomes the commit subject — keeping bot-PR titles conventional prevents this list from ever growing.

## Testing
- The two subjects in the list are byte-compared against `git log --format=%s` of `60e03e4` / `799ae75` (exact match verified).
- This PR's own `Commit style validation` run is the end-to-end test: the new-branch push lints history containing both Copilot commits with this config, so a green check here proves the exemption works (no local Node runtime was available).
- Whitespace/EOF pre-commit hooks pass on the changed file.

## After merge
The four open feature PRs (#226–#228, #231) need one more trivial rebase onto `dev` to pick up this config — all their other checks are already green post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
