### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-08-03
+
 ### Added
 
 - **`gg.configure()` is public and can target a custom handler name.** The
@@ -31,8 +33,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   single bus shared by every process on a socket, so a name is global
   application state -- one name per output destination, defined once as a
   module-level constant and shared across entry points. On a conflict the
-  first registration wins silently and only the later handler's scopes are
-  merged onto it.
+  first registration wins and only the later handler's scopes are merged
+  onto it.
 
 ### Fixed
 
@@ -65,6 +67,17 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   dedicated-host setup (and follows `GOGGLES_HOST_LOG` when that is set).
   Behavior is otherwise unchanged: the first handler still wins, scopes are
   still merged, and no exception is raised.
+
+## [0.3.1] - 2026-06-11
+
+### Fixed
+
+- **Caller capture no longer pins frame stacks until the collector runs.**
+  `_caller_id()` held the frame returned by `inspect.currentframe()` in a
+  local, so the frame referenced itself -- a cycle refcounting cannot
+  reclaim, keeping the whole `f_back` chain (and everything its locals
+  reference) alive until a `gc` pass. The frame is now dropped on every
+  path. Only relevant when caller capture is on (`GOGGLES_CAPTURE_CALLER`).
 
 ## [0.3.0] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ gg.attach(
 ```
 
 > [!WARNING]
-> **On a name conflict the first registration wins, silently.** Attaching a handler under a name the bus already knows neither replaces it nor raises: the later instance — with its own level, path, project, ... — is ignored, and only its `scopes` are merged onto the handler already registered under that name. So two names for one destination duplicate that destination's output, while one name for two different configurations keeps whichever process attached first.
+> **On a name conflict the first registration wins.** Attaching a handler under a name the bus already knows neither replaces it nor raises: the later instance — with its own level, path, project, ... — is ignored, and only its `scopes` are merged onto the handler already registered under that name. When the ignored handler's configuration differs from the registered one, a warning naming the handler and the differing options goes to the host's stderr; re-attaching an identical configuration is the idempotent case and stays silent. So two names for one destination duplicate that destination's output, while one name for two different configurations keeps whichever process attached first.
 
 Names and scopes are independent: the name decides *which handler instance* the bus keeps, the scopes decide *which events reach it*. Re-attaching the same name under new scopes is therefore the supported way to widen an existing handler's routing.
 
 ### Idempotent console setup
 
-`gg.configure()` is a one-call shortcut for the console-only setup above, and the only handler-setup path where the **last call wins**: it detaches the console handler already attached to each target scope before attaching a fresh one, so the most recent options take effect. `gg.attach()` instead dedupes by handler name and silently keeps the first handler registered.
+`gg.configure()` is a one-call shortcut for the console-only setup above, and the only handler-setup path where the **last call wins**: it detaches the console handler already attached to each target scope before attaching a fresh one, so the most recent options take effect. `gg.attach()` instead dedupes by handler name and keeps the first handler registered, warning on stderr when a later attach's options differ.
 
 ```python
 import goggles as gg

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -125,11 +125,12 @@ bus.
 `EventBus.attach` keys its handler registry by `handler.name`, and there
 is one bus per socket shared by every process on it (§4). A name is
 therefore global application state, not a local label: the first
-registration under a name wins, later ones are dropped silently and only
-their scopes merge onto the incumbent. Use one name per output
-destination and define it once as a module-level constant shared across
-entry points. See [Handler naming](../../README.md#handler-naming) in
-the README for the user-facing guidance.
+registration under a name wins, later ones are dropped -- warning on
+stderr when their configuration differs -- and only their scopes merge
+onto the incumbent. Use one name per output destination and define it
+once as a module-level constant shared across entry points. See
+[Handler naming](../../README.md#handler-naming) in the README for the
+user-facing guidance.
 
 ### 4. Transport (`_core/transport/`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robo-goggles"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
     { name = "Antonio Terpin", email = "aterpin@ethz.ch" },
     { name = "Francesco Banelli", email = "fbanelli@ethz.ch" },

--- a/uv.lock
+++ b/uv.lock
@@ -2139,7 +2139,7 @@ wheels = [
 
 [[package]]
 name = "robo-goggles"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "imageio" },


### PR DESCRIPTION
Prepares the **v0.3.2** release: closes the `[Unreleased]` section, bumps the version, and corrects wording that this release's own changes invalidated.

## Changes
- **Version bump** to `0.3.2` in `pyproject.toml` and the `uv.lock` self-entry (`uv lock --check` passes). The lock's self-pin is bumped by hand rather than via `uv lock`, which wanted to rewrite 27 unrelated dependency-marker lines — worth doing deliberately in its own PR, not silently inside a release commit.
- **`[0.3.2]` changelog section** covering what merged since v0.3.1: the `attach()` name-conflict warning (#228), custom `WandBHandler` names (#226), the public `configure(name=...)` (#227), and the handler-naming documentation (#231).
- **Backfilled the missing `[0.3.1]` section.** That release shipped the `_caller_id` frame-cycle fix (#220), but its release commit only bumped `pyproject.toml`, so the changelog jumped straight from `[Unreleased]` to `[0.3.0]` and the fix was never documented.
- **Corrected the handler-conflict wording** in the README, the architecture guide, and the `[0.3.2]` changelog entry. All three said conflicts are resolved *silently* — true when #231 was written, but #228 landed in this same release and now warns on stderr whenever a dropped handler's configuration differs. Without this, v0.3.2 would ship documentation contradicting its own behavior.

## Why a patch bump
`configure` being exported and the new `name=` parameters are additive and fully backward compatible (every new parameter defaults to the prior behavior), and the `attach()` change only adds a diagnostic. Nothing existing changes semantics, so this is a patch release.

## Testing
- `uv run pytest`: 721 passed, 4 skipped.
- `uv lock --check`: consistent.
- Pre-commit hooks pass on all touched files.

## After merge
`dev` → `main` merge, then tag `v0.3.2` on `main` — the tag is what triggers `release.yaml` to build, publish to PyPI, and create the GitHub release. I have deliberately not tagged or pushed anything to `main`: publishing is irreversible and yours to trigger.

## Note: a flaky test worth its own issue
`tests/core/test_logger.py::test_caller_id_does_not_leak_frame_cycles` fails intermittently (~2 in 5 full-suite runs locally) and passes in isolation. It is **pre-existing and unrelated to this PR** — I reproduced it on unmodified `dev` before making any change here. It is GC-timing sensitive, and notably it is the test guarding the very fix backfilled above. Happy to open an issue if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
