### PR TITLE
Merge branch 'dev' for v0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **`gg.configure()` is public and can target a custom handler name.** The
+  idempotent console setup was reachable but absent from `goggles.__all__`
+  and undocumented; it is now part of the public surface and covered in the
+  README. Its new `name=` argument selects which console handler to replace
+  and attach (defaulting to the `ConsoleHandler` class default, so existing
+  callers are unaffected), so applications that namespace their handlers
+  (e.g. `"myapp.console"`) also get the last-call-wins semantics. (#224)
 - **`WandBHandler` accepts a custom handler name.** The event bus keys handlers
   by name (one host bus per socket, shared across processes), so two
   `WandBHandler`s could never coexist: the second one -- project and all -- was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   construction. The name defaults to `"wandb"` and now round-trips through
   `to_dict()`/`from_dict()`; serialized payloads without it (older clients
   attaching to a newer host) still rebuild with the default.
+- **`attach()` now warns when a handler-name conflict silently drops a
+  configuration.** Handlers are keyed by `handler.name` and the first writer
+  wins, so attaching a second handler under a name that is already registered
+  discarded the newcomer -- its level, project, path and every other setting --
+  while still merging its scopes onto the *first* instance. That happened
+  silently, so a mistyped (or copy-pasted) name looked like it worked and then
+  logged with somebody else's configuration. The bus now emits a warning that
+  names the handler, lists only the config keys that actually differ (or
+  reports that the handler *class* differs), and states that the first
+  registration is kept. Re-attaching an identical configuration remains the
+  intended idempotent case and stays completely silent. The warning goes to
+  the host's stderr -- the same stream `ConsoleHandler` output and the other
+  host diagnostics already use -- so it is visible by default in the
+  dedicated-host setup (and follows `GOGGLES_HOST_LOG` when that is set).
+  Behavior is otherwise unchanged: the first handler still wins, scopes are
+  still merged, and no exception is raised.
 
 ## [0.3.0] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- **`WandBHandler` accepts a custom handler name.** The event bus keys handlers
+  by name (one host bus per socket, shared across processes), so two
+  `WandBHandler`s could never coexist: the second one -- project and all -- was
+  silently dropped. Pass `WandBHandler(..., name="wandb.eval")` to attach
+  several W&B handlers side by side instead of mutating `handler.name` after
+  construction. The name defaults to `"wandb"` and now round-trips through
+  `to_dict()`/`from_dict()`; serialized payloads without it (older clients
+  attaching to a newer host) still rebuild with the default.
+
 ## [0.3.0] - 2026-06-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-08-03
+
 ### Added
 
 - **`gg.configure()` is public and can target a custom handler name.** The
@@ -31,8 +33,8 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   single bus shared by every process on a socket, so a name is global
   application state -- one name per output destination, defined once as a
   module-level constant and shared across entry points. On a conflict the
-  first registration wins silently and only the later handler's scopes are
-  merged onto it.
+  first registration wins and only the later handler's scopes are merged
+  onto it.
 
 ### Fixed
 
@@ -65,6 +67,17 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   dedicated-host setup (and follows `GOGGLES_HOST_LOG` when that is set).
   Behavior is otherwise unchanged: the first handler still wins, scopes are
   still merged, and no exception is raised.
+
+## [0.3.1] - 2026-06-11
+
+### Fixed
+
+- **Caller capture no longer pins frame stacks until the collector runs.**
+  `_caller_id()` held the frame returned by `inspect.currentframe()` in a
+  local, so the frame referenced itself -- a cycle refcounting cannot
+  reclaim, keeping the whole `f_back` chain (and everything its locals
+  reference) alive until a `gc` pass. The frame is now dropped on every
+  path. Only relevant when caller capture is on (`GOGGLES_CAPTURE_CALLER`).
 
 ## [0.3.0] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,31 @@ project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   construction. The name defaults to `"wandb"` and now round-trips through
   `to_dict()`/`from_dict()`; serialized payloads without it (older clients
   attaching to a newer host) still rebuild with the default.
+- **Handler naming is documented as the bus-wide dedup key.** A new
+  "Handler naming" section in the README (cross-referenced from
+  [docs/guides/architecture.md](docs/guides/architecture.md) §3) spells out
+  what was previously only implicit: `attach` keys handlers by `name` on the
+  single bus shared by every process on a socket, so a name is global
+  application state -- one name per output destination, defined once as a
+  module-level constant and shared across entry points. On a conflict the
+  first registration wins silently and only the later handler's scopes are
+  merged onto it.
+
+### Fixed
+
+- **README multi-scope example routed to the wrong handlers.** The snippet
+  called `logger_scope2.bind(scope="scope2")` without assigning the result --
+  `bind` returns a new logger and does not mutate the receiver -- so the
+  logger kept its original scope and its "logged only by handler2" line
+  reached *both* handlers. The neighbouring namespace line, emitted on a
+  scope with no attached handler, reached *none*. Both now do what the
+  surrounding text claims.
+- **Examples no longer share handler names across files.**
+  `examples/01_basic_run.py` and `examples/102_decorators.py` both attached
+  `"examples.basic.console"` but at different levels, so running both in one
+  session silently kept whichever attached first. Every example now declares
+  its handler names as module-level constants under a single
+  `examples.<topic>.<destination>` scheme.
 - **`attach()` now warns when a handler-name conflict silently drops a
   configuration.** Handlers are keyed by `handler.name` and the first writer
   wins, so attaching a second handler under a name that is already registered

--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ See also [Example 1](./examples/01_basic_run.py), which you can run after clonin
 uv run examples/01_basic_run.py
 ```
 
+### Idempotent console setup
+
+`gg.configure()` is a one-call shortcut for the console-only setup above, and the only handler-setup path where the **last call wins**: it detaches the console handler already attached to each target scope before attaching a fresh one, so the most recent options take effect. `gg.attach()` instead dedupes by handler name and silently keeps the first handler registered.
+
+```python
+import goggles as gg
+import logging
+
+# Attaches a ConsoleHandler on the "global" scope.
+gg.configure(enable_console=True, console_level=logging.INFO)
+
+# A later call wins: the handler above is replaced, not deduped.
+gg.configure(enable_console=True, console_level=logging.WARNING)
+
+# Namespace the handler when your application owns its own console.
+gg.configure(enable_console=True, name="myapp.console", scopes=["global"])
+```
+
+Prefer `configure()` over `attach()` when several call sites — or several processes sharing one host, see [Multi-process logging](#multi-process-logging-same-machine) — may set up the console and must converge on a single configuration regardless of arrival order; use `attach()` with explicit handler instances for everything else. Calling `gg.configure()` with no arguments is a no-op, so it is safe to invoke unconditionally during initialization.
+
 ### Experiment tracking with W&B
 
 ```python

--- a/README.md
+++ b/README.md
@@ -82,6 +82,31 @@ See also [Example 1](./examples/01_basic_run.py), which you can run after clonin
 uv run examples/01_basic_run.py
 ```
 
+### Handler naming
+
+Every handler carries a `name`, and the event bus identifies it by that name alone. There is a single bus per `GOGGLES_SOCKET`, shared by every process that connects to it, so **handler names are global to your whole application** — not per module, not per process. Give each output destination exactly one name, and define those names once as module-level constants that every entry point imports, rather than retyping a string at each `attach` call site.
+
+```python
+# myapp/logging_setup.py -- one definition, imported everywhere
+CONSOLE_HANDLER_NAME = "myapp.console"
+STORAGE_HANDLER_NAME = "myapp.storage"
+```
+
+```python
+# any entry point: trainer, evaluator, dataloader worker, ...
+from myapp.logging_setup import CONSOLE_HANDLER_NAME
+
+gg.attach(
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
+    scopes=["global"],
+)
+```
+
+> [!WARNING]
+> **On a name conflict the first registration wins, silently.** Attaching a handler under a name the bus already knows neither replaces it nor raises: the later instance — with its own level, path, project, ... — is ignored, and only its `scopes` are merged onto the handler already registered under that name. So two names for one destination duplicate that destination's output, while one name for two different configurations keeps whichever process attached first.
+
+Names and scopes are independent: the name decides *which handler instance* the bus keeps, the scopes decide *which events reach it*. Re-attaching the same name under new scopes is therefore the supported way to widen an existing handler's routing.
+
 ### Idempotent console setup
 
 `gg.configure()` is a one-call shortcut for the console-only setup above, and the only handler-setup path where the **last call wins**: it detaches the console handler already attached to each target scope before attaching a fresh one, so the most recent options take effect. `gg.attach()` instead dedupes by handler name and silently keeps the first handler registered.
@@ -251,18 +276,24 @@ Within the same run, we may have logs that belong to different scopes. An exampl
 #### Usage
 
 ```python
-# In this example, we set up a handlers associated
-# to different scopes.
-handler1 = gg.ConsoleHandler(name="examples.basic.console.1", level=logging.INFO)
+# In this example, we set up a handlers associated to different scopes.
+# Handler names are bus-wide identities, so we define them once
+# (see "Handler naming" above).
+HANDLER1_NAME = "examples.multi_scope.console.1"
+HANDLER2_NAME = "examples.multi_scope.console.2"
+
+handler1 = gg.ConsoleHandler(name=HANDLER1_NAME, level=logging.INFO)
 gg.attach(handler1, scopes=["global", "scope1"])
 
-handler2 = gg.ConsoleHandler(name="examples.basic.console.2", level=logging.INFO)
+handler2 = gg.ConsoleHandler(name=HANDLER2_NAME, level=logging.INFO)
 gg.attach(handler2, scopes=["global", "scope2"])
 
 # We need to get separate loggers for each scope
 logger_scope1 = gg.get_logger("examples.basic.scope1", scope="scope1")
 logger_scope2 = gg.get_logger("examples.basic.scope2")
-logger_scope2.bind(scope="scope2")  # You can also bind the scope after creation
+# `bind` returns a new logger, it does not mutate the receiver: the
+# result has to be assigned for the new scope to take effect.
+logger_scope2 = logger_scope2.bind(scope="scope2")
 logger_global = gg.get_logger("examples.basic.global", scope="global")
 
 # Now we can log messages to different scopes, so that only the interested
@@ -271,9 +302,11 @@ logger_scope1.info(f"This will be logged only by {handler1.name}")
 logger_scope2.info(f"This will be logged only by {handler2.name}")
 logger_global.info("This will be logged by both handlers.")
 
-# The same result can be achieved using namespaces,
-# which are indicated by dot notation.
-logger_namespace = gg.get_logger("examples.basic.namespace", scope="namespace")
+# Scopes are hierarchical, with the levels indicated by dot notation, so a
+# child scope also reaches the handlers attached to its parent.
+logger_namespace = gg.get_logger(
+    "examples.basic.namespace", scope="global.namespace"
+)
 logger_namespace.info("This will be logged by both handlers.")
 
 gg.finish()

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ gg.attach(
 ```
 
 > [!WARNING]
-> **On a name conflict the first registration wins, silently.** Attaching a handler under a name the bus already knows neither replaces it nor raises: the later instance — with its own level, path, project, ... — is ignored, and only its `scopes` are merged onto the handler already registered under that name. So two names for one destination duplicate that destination's output, while one name for two different configurations keeps whichever process attached first.
+> **On a name conflict the first registration wins.** Attaching a handler under a name the bus already knows neither replaces it nor raises: the later instance — with its own level, path, project, ... — is ignored, and only its `scopes` are merged onto the handler already registered under that name. When the ignored handler's configuration differs from the registered one, a warning naming the handler and the differing options goes to the host's stderr; re-attaching an identical configuration is the idempotent case and stays silent. So two names for one destination duplicate that destination's output, while one name for two different configurations keeps whichever process attached first.
 
 Names and scopes are independent: the name decides *which handler instance* the bus keeps, the scopes decide *which events reach it*. Re-attaching the same name under new scopes is therefore the supported way to widen an existing handler's routing.
 
 ### Idempotent console setup
 
-`gg.configure()` is a one-call shortcut for the console-only setup above, and the only handler-setup path where the **last call wins**: it detaches the console handler already attached to each target scope before attaching a fresh one, so the most recent options take effect. `gg.attach()` instead dedupes by handler name and silently keeps the first handler registered.
+`gg.configure()` is a one-call shortcut for the console-only setup above, and the only handler-setup path where the **last call wins**: it detaches the console handler already attached to each target scope before attaching a fresh one, so the most recent options take effect. `gg.attach()` instead dedupes by handler name and keeps the first handler registered, warning on stderr when a later attach's options differ.
 
 ```python
 import goggles as gg

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -11,6 +11,20 @@
 // `Agent-Logs-Url:` URLs) that legitimately exceed 100 characters,
 // and the workflow re-lints merged history on every downstream push,
 // so a single long trailer would otherwise poison future merges.
+
+// Squash-merge subjects already in main/dev history that predate
+// conventional-title enforcement for bot PRs (#229, #230). History
+// cannot be rewritten, and the workflow re-lints history on every
+// push (force-pushes lint deep history), so these exact first lines
+// are permanently exempted. Exact match only: new commits stay fully
+// linted. When squash-merging a PR, the PR title becomes the commit
+// subject -- keep it conventional so this list never grows.
+const LEGACY_SQUASH_SUBJECTS = [
+    'Pin Pillow to patched version to unblock pip-audit workflow (#229)',
+    'Resolve pip-audit CI failure by upgrading Pillow to a patched' +
+        ' version (#230)',
+];
+
 export default {
     extends: ['@commitlint/config-conventional'],
     ignores: [
@@ -18,6 +32,8 @@ export default {
             /^Merge (pull request|branch|remote-tracking branch) /.test(
                 message,
             ),
+        (message) =>
+            LEGACY_SQUASH_SUBJECTS.includes(message.split('\n')[0]),
     ],
     rules: {
         'body-max-line-length': [0],

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -46,7 +46,7 @@ public surface is (see [goggles/__init__.py](../../goggles/__init__.py)):
 - Event model: `Event`, `Kind`, `Metrics`, `Image`, `Video`,
   `Vector`, `VectorField`
 - Handlers: `ConsoleHandler`, `LocalStorageHandler`, `WandBHandler`
-- Bus management: `attach`, `detach`, `register_handler`
+- Bus management: `attach`, `configure`, `detach`, `register_handler`
 - Decorators: `timeit`, `trace_on_error`
 - Config: `PrettyConfig`, `load_configuration`, `save_configuration`
 - Shutdown: `GracefulShutdown`

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -120,6 +120,17 @@ Adding a new handler: subclass an existing handler or implement the
 `register_handler()` so it can be serialized for transport across the
 bus.
 
+#### Handler names are the bus-wide dedup key
+
+`EventBus.attach` keys its handler registry by `handler.name`, and there
+is one bus per socket shared by every process on it (§4). A name is
+therefore global application state, not a local label: the first
+registration under a name wins, later ones are dropped silently and only
+their scopes merge onto the incumbent. Use one name per output
+destination and define it once as a module-level constant shared across
+entry points. See [Handler naming](../../README.md#handler-naming) in
+the README for the user-facing guidance.
+
 ### 4. Transport (`_core/transport/`)
 
 See [transport.md](transport.md) for the package layout (frames,

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -125,11 +125,12 @@ bus.
 `EventBus.attach` keys its handler registry by `handler.name`, and there
 is one bus per socket shared by every process on it (§4). A name is
 therefore global application state, not a local label: the first
-registration under a name wins, later ones are dropped silently and only
-their scopes merge onto the incumbent. Use one name per output
-destination and define it once as a module-level constant shared across
-entry points. See [Handler naming](../../README.md#handler-naming) in
-the README for the user-facing guidance.
+registration under a name wins, later ones are dropped -- warning on
+stderr when their configuration differs -- and only their scopes merge
+onto the incumbent. Use one name per output destination and define it
+once as a module-level constant shared across entry points. See
+[Handler naming](../../README.md#handler-naming) in the README for the
+user-facing guidance.
 
 ### 4. Transport (`_core/transport/`)
 

--- a/examples/01_basic_run.py
+++ b/examples/01_basic_run.py
@@ -1,9 +1,14 @@
 import goggles as gg
 
+# A handler name is the bus-wide identity of a destination, so define it
+# once here rather than retyping the string at every attach call site.
+CONSOLE_HANDLER_NAME = "examples.basic.console"
+DEBUG_CONSOLE_HANDLER_NAME = "examples.basic.debug_console"
+
 # In this basic example, we set up a logger that outputs to the console.
 logger = gg.get_logger("examples.basic")
 gg.attach(
-    gg.ConsoleHandler(name="examples.basic.console", level=gg.INFO),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
     scopes=["global"],
 )
 
@@ -18,7 +23,7 @@ logger.critical("This is critical!")
 
 # Lowering handler log level makes debug messages visible.
 gg.attach(
-    gg.ConsoleHandler(name="examples.basic.debug_console", level=gg.DEBUG),
+    gg.ConsoleHandler(name=DEBUG_CONSOLE_HANDLER_NAME, level=gg.DEBUG),
     scopes=["global"],
 )
 

--- a/examples/02_multi_scope.py
+++ b/examples/02_multi_scope.py
@@ -1,11 +1,16 @@
 import goggles as gg
 
+# Each console handler needs its own bus-wide name; define them once here.
+HANDLER1_NAME = "examples.multi_scope.console.1"
+HANDLER2_NAME = "examples.multi_scope.console.2"
+HANDLER3_NAME = "examples.multi_scope.console.3"
+
 # In this example, we set up a handlers associated
 # to different scopes.
-handler1 = gg.ConsoleHandler(name="examples.basic.console.1", level=gg.INFO)
+handler1 = gg.ConsoleHandler(name=HANDLER1_NAME, level=gg.INFO)
 gg.attach(handler1, scopes=["global", "namespace.scope1"])
 
-handler2 = gg.ConsoleHandler(name="examples.basic.console.2", level=gg.INFO)
+handler2 = gg.ConsoleHandler(name=HANDLER2_NAME, level=gg.INFO)
 gg.attach(handler2, scopes=["global", "namespace.scope2"])
 
 # We need to get separate loggers for each scope
@@ -24,7 +29,7 @@ logger_global.info("This will be logged by both handlers.")
 
 # The same result can be achieved using namespaces,
 # which are indicated by dot notation.
-handler3 = gg.ConsoleHandler(name="examples.basic.console.3", level=gg.INFO)
+handler3 = gg.ConsoleHandler(name=HANDLER3_NAME, level=gg.INFO)
 gg.attach(handler3, scopes=["namespace"])
 logger_scope1.info(
     f"This will be logged by {handler1.name} and {handler3.name}"

--- a/examples/03_local_storage.py
+++ b/examples/03_local_storage.py
@@ -4,6 +4,10 @@ import numpy as np
 
 import goggles as gg
 
+# One name per output destination, defined once for the whole example.
+STORAGE_HANDLER_NAME = "examples.jsonl.storage"
+CONSOLE_HANDLER_NAME = "examples.jsonl.console"
+
 # In this example, we set up a logger that stores events
 # in a structured directory:
 # - examples/logs/log.jsonl: Main JSONL log file with all events
@@ -20,11 +24,11 @@ logger = gg.get_logger("examples.jsonl", with_metrics=True)
 gg.attach(
     gg.LocalStorageHandler(
         path=Path("examples/logs"),
-        name="examples.jsonl",
+        name=STORAGE_HANDLER_NAME,
     )
 )
 gg.attach(
-    gg.ConsoleHandler(name="examples.jsonl.console", level=gg.INFO),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
 )
 
 print("=== Goggles Local Storage Handler Example ===")

--- a/examples/06_custom_handler.py
+++ b/examples/06_custom_handler.py
@@ -1,5 +1,7 @@
 import goggles as gg
 
+CONSOLE_HANDLER_NAME = "examples.custom.console"
+
 
 class CustomConsoleHandler(gg.ConsoleHandler):
     """A custom console handler that adds a prefix to each log message."""
@@ -21,7 +23,7 @@ logger = gg.get_logger("examples.custom_handler")
 
 
 gg.attach(
-    CustomConsoleHandler(name="examples.custom.console", level=gg.INFO),
+    CustomConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
     scopes=["global"],
 )
 # Because the logging level is set to INFO, the debug message will not be shown.

--- a/examples/07_library_vs_app.py
+++ b/examples/07_library_vs_app.py
@@ -38,6 +38,12 @@ def library_work():
 
 
 # ------------------ Application code (what an app would do) ------------------
+# The app owns the handler names: one per output destination, declared once
+# here so every entry point attaches under the very same identity.
+CONSOLE_HANDLER_NAME = "examples.app.console"
+STORAGE_HANDLER_NAME = "examples.app.storage"
+
+
 def setup_logging(project_root: Path | str = "examples/logs") -> None:
     """Set up handlers for the application.
 
@@ -56,12 +62,15 @@ def setup_logging(project_root: Path | str = "examples/logs") -> None:
     project_root = Path(project_root)
     # Console for general messages (global)
     gg.attach(
-        gg.ConsoleHandler(name="app.console", level=gg.INFO), scopes=["global"]
+        gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
+        scopes=["global"],
     )
 
     # Local storage for library events (stored under examples/logs/library)
     gg.attach(
-        gg.LocalStorageHandler(path=project_root / "library", name="app.local"),
+        gg.LocalStorageHandler(
+            path=project_root / "library", name=STORAGE_HANDLER_NAME
+        ),
         scopes=[LIBRARY_SCOPE],
     )
 

--- a/examples/08_dedicated_host.py
+++ b/examples/08_dedicated_host.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import goggles as gg
 
+STORAGE_HANDLER_NAME = "examples.dedicated_host.storage"
+
 
 def main() -> None:
     """Log a few events; the handler runs in the dedicated host subprocess."""
@@ -31,7 +33,7 @@ def main() -> None:
 
     gg.attach(
         gg.LocalStorageHandler(
-            path=Path("examples/logs/dedicated"), name="local"
+            path=Path("examples/logs/dedicated"), name=STORAGE_HANDLER_NAME
         ),
         scopes=["global"],
     )

--- a/examples/100_interrupt.py
+++ b/examples/100_interrupt.py
@@ -7,12 +7,12 @@ from types import FrameType
 import goggles as gg
 from goggles._core.integrations import ConsoleHandler
 
+CONSOLE_HANDLER_NAME = "examples.interrupt.console"
+
 # Instantiate a TextLogger (No metrics)
 logger = gg.get_logger("examples.interrupt")
 
-gg.attach(
-    ConsoleHandler(name="examples.interrupt.info", level=gg.INFO), ["global"]
-)
+gg.attach(ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO), ["global"])
 
 _prev_sigint_handler = signal.getsignal(signal.SIGINT)
 

--- a/examples/102_decorators.py
+++ b/examples/102_decorators.py
@@ -6,9 +6,14 @@ untyped. You can safely ignore these warnings with # type: ignore[misc].
 
 import goggles as gg
 
+# Handler names are bus-wide, so this example owns its own name instead of
+# reusing the one from `01_basic_run.py` (which attaches at INFO: sharing a
+# name would silently keep whichever of the two attached first).
+CONSOLE_HANDLER_NAME = "examples.decorators.console"
+
 gg.attach(
     gg.ConsoleHandler(
-        name="examples.basic.console", level=gg.DEBUG
+        name=CONSOLE_HANDLER_NAME, level=gg.DEBUG
     ),  # Changed to DEBUG to see timeit output
     scopes=["global"],
 )

--- a/examples/104_filters.py
+++ b/examples/104_filters.py
@@ -33,9 +33,11 @@ from goggles.filters import (
     create_concat_filter,
 )
 
+CONSOLE_HANDLER_NAME = "examples.filters.console"
+
 # Set up logging
 gg.attach(
-    gg.ConsoleHandler(name="examples.filters.console", level=gg.INFO),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
     scopes=["global"],
 )
 logger = gg.get_logger("examples.filters")

--- a/examples/105_benchmark.py
+++ b/examples/105_benchmark.py
@@ -106,6 +106,8 @@ os.environ["PYTHONPATH"] = (
 
 from _benchmark_handlers import DeliveryCounter  # noqa: E402
 
+CONSOLE_HANDLER_NAME = "examples.benchmark.console"
+
 # ``_logger`` is populated inside the per-preset subprocess (see
 # ``_run_benchmark``). Creating it at module import would make the parent
 # Hydra process bind the goggles socket, which subsequently spawned
@@ -516,7 +518,7 @@ def _run_benchmark(cfg: DictConfig) -> None:
 
     gg.attach(
         gg.ConsoleHandler(
-            name="goggles.benchmark.console",
+            name=CONSOLE_HANDLER_NAME,
             level=gg.INFO,
         ),
         scopes=["goggles.benchmark"],

--- a/examples/106_log_levels.py
+++ b/examples/106_log_levels.py
@@ -2,11 +2,13 @@ import logging
 
 import goggles as gg
 
+CONSOLE_HANDLER_NAME = "examples.levels.console"
+
 # A console handler that lets DEBUG and above through. Per-logger level
 # filtering happens *before* the handler, so the handler stays permissive
 # and each logger decides what it emits.
 gg.attach(
-    gg.ConsoleHandler(name="examples.levels.console", level=gg.DEBUG),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.DEBUG),
     scopes=["global"],
 )
 

--- a/examples/107_push_images.py
+++ b/examples/107_push_images.py
@@ -11,12 +11,15 @@ import goggles as gg
 # channel axis in {1, 3, 4}.
 
 LOG_DIR = Path("examples/logs/107_push")
+STORAGE_HANDLER_NAME = "examples.push.storage"
+CONSOLE_HANDLER_NAME = "examples.push.console"
+
 logger = gg.get_logger("examples.push", with_metrics=True)
 gg.attach(
-    gg.LocalStorageHandler(path=LOG_DIR, name="examples.push"),
+    gg.LocalStorageHandler(path=LOG_DIR, name=STORAGE_HANDLER_NAME),
 )
 gg.attach(
-    gg.ConsoleHandler(name="examples.push.console", level=gg.INFO),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
 )
 
 print(f"=== writing logs to {LOG_DIR} ===\n")

--- a/examples/108_class_level_logger.py
+++ b/examples/108_class_level_logger.py
@@ -16,6 +16,8 @@ handlers the application installs later. No re-bind is needed.
 
 import goggles as gg
 
+CONSOLE_HANDLER_NAME = "examples.class_level.console"
+
 
 class Worker:
     """A class that holds its logger as a class attribute.
@@ -60,7 +62,7 @@ w2 = Worker("beta")
 # Application setup happens *after* Worker has been imported and its
 # class-level logger has already been built.
 gg.attach(
-    gg.ConsoleHandler(name="examples.class_level.console", level=gg.INFO),
+    gg.ConsoleHandler(name=CONSOLE_HANDLER_NAME, level=gg.INFO),
     scopes=["global"],
 )
 

--- a/examples/_benchmark_handlers.py
+++ b/examples/_benchmark_handlers.py
@@ -18,6 +18,8 @@ from typing import ClassVar
 import goggles as gg
 from goggles import Event, Kind
 
+COUNTER_HANDLER_NAME = "examples.benchmark.counter"
+
 
 class DeliveryCounter:
     """Counts events delivered to the host, persisting totals to a file.
@@ -32,7 +34,7 @@ class DeliveryCounter:
         capabilities: Event kinds this handler claims to handle.
     """
 
-    name = "goggles.benchmark.counter"
+    name = COUNTER_HANDLER_NAME
     capabilities: ClassVar[frozenset[Kind]] = frozenset(
         {
             "log",

--- a/goggles/__init__.py
+++ b/goggles/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import gc
 import logging
 import os
+import sys
 import threading
 from collections import defaultdict
 from collections.abc import Callable
@@ -810,6 +811,108 @@ class Handler(Protocol):
 # ---------------------------------------------------------------------------
 # EventBus and run management
 # ---------------------------------------------------------------------------
+
+# Longest config value inlined in a conflict warning; longer ones are elided.
+_MAX_REPORTED_VALUE_CHARS = 40
+
+_UNSET = object()
+
+
+def _short_repr(value: object) -> str:
+    """Render a handler config value compactly.
+
+    Args:
+        value: The value to render.
+
+    Returns:
+        The value's repr, or a placeholder when the key is absent from the
+        config or its repr is too long to inline in a warning.
+
+    """
+    if value is _UNSET:
+        text = "<unset>"
+    else:
+        text = repr(value)
+        if len(text) > _MAX_REPORTED_VALUE_CHARS:
+            text = "<omitted>"
+    return text
+
+
+def _differing_config_keys(kept: dict, ignored: dict) -> list[str]:
+    """List the keys whose values differ between two handler configs.
+
+    Args:
+        kept: Config data of the handler that stays registered.
+        ignored: Config data of the handler that is dropped.
+
+    Returns:
+        One short description per differing key.
+
+    """
+    differences = []
+    for key in sorted(set(kept) | set(ignored)):
+        old = kept.get(key, _UNSET)
+        new = ignored.get(key, _UNSET)
+        if old != new:
+            differences.append(
+                f"{key} (kept {_short_repr(old)}, ignored {_short_repr(new)})"
+            )
+    return differences
+
+
+def _describe_handler_conflict(kept: dict, ignored: dict) -> str | None:
+    """Describe how a dropped handler differs from the registered one.
+
+    Args:
+        kept: Serialized form of the already-registered handler.
+        ignored: Serialized handler that is about to be dropped.
+
+    Returns:
+        A short description of the difference, or None when the two
+        serialized handlers are identical.
+
+    """
+    description = None
+    if kept.get("cls") != ignored.get("cls"):
+        description = (
+            f"handler class differs (kept {kept.get('cls')!r}, "
+            f"ignored {ignored.get('cls')!r})"
+        )
+    else:
+        keys = _differing_config_keys(
+            kept.get("data") or {}, ignored.get("data") or {}
+        )
+        if keys:
+            description = "config differs in " + "; ".join(keys)
+    return description
+
+
+def _warn_handler_conflict(registered: Handler, incoming: dict) -> None:
+    """Warn on stderr that a differing same-named handler was dropped.
+
+    Stays silent when the incoming handler serializes exactly like the
+    registered one, which is the intended idempotent re-attach.
+
+    The bus usually runs in the dedicated host process, which inherits the
+    application's stderr (or ``GOGGLES_HOST_LOG``), so stderr is where the
+    host's other diagnostics already surface.
+
+    Args:
+        registered: The handler already registered under this name.
+        incoming: Serialized handler that ``attach`` is dropping.
+
+    """
+    difference = _describe_handler_conflict(registered.to_dict(), incoming)
+    if difference is not None:
+        print(
+            f"goggles: attach() name conflict for handler "
+            f"'{registered.name}': {difference}. Keeping the first "
+            f"registration; the new configuration is ignored.",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
 class EventBus:
     """Process-wide event router.
 
@@ -884,6 +987,11 @@ class EventBus:
     def attach(self, handlers: list[dict], scopes: list[str]) -> None:
         """Attach handler(s) under the given scopes.
 
+        Handlers are keyed by name, first writer wins: attaching a differing
+        configuration under an already-registered name keeps the first
+        handler and warns on stderr, while still merging the given scopes.
+        Re-attaching an identical configuration is silent.
+
         Args:
             handlers:
                 The serialized handlers to attach to the scopes.
@@ -894,17 +1002,19 @@ class EventBus:
             handler_class = _get_handler_class(handler_dict["cls"])
             handler = handler_class.from_dict(handler_dict["data"])
             with self._lock:
-                newly_added = handler.name not in self.handlers
-                if newly_added:
+                registered = self.handlers.get(handler.name)
+                if registered is None:
                     self.handlers[handler.name] = handler
                 for scope in scopes:
                     if scope not in self.scopes:
                         self.scopes[scope] = set()
                     self.scopes[scope].add(handler.name)
-            if newly_added:
+            if registered is None:
                 # Call handler.open() outside the lock: it may do I/O
                 # (e.g. open a wandb run) and must not block readers.
                 handler.open()
+            else:
+                _warn_handler_conflict(registered, handler_dict)
 
     def detach(self, handler_name: str, scope: str) -> None:
         """Detach a handler from the given scope.

--- a/goggles/__init__.py
+++ b/goggles/__init__.py
@@ -1029,6 +1029,7 @@ def configure(
     console_path_style: Literal["absolute", "relative"] = "relative",
     project_root: str | os.PathLike[str] | None = None,
     scopes: list[str] | None = None,
+    name: str | None = None,
 ) -> None:
     """One-call shortcut for the common "I just want a console logger" setup.
 
@@ -1047,8 +1048,12 @@ def configure(
 
     Calling ``configure(enable_console=True, ...)`` while a console handler
     is already attached to the target ``scopes`` re-attaches a fresh handler
-    with the new options (the old one is detached first), so the second call
-    wins instead of being silently deduped by name.
+    with the new options (the old one is detached first), so the **last call
+    wins** instead of being silently deduped by name. This makes it the
+    setup path of choice for multi-process applications, where several
+    processes race to configure the shared bus and must converge on one
+    console configuration regardless of arrival order -- unlike ``attach``,
+    which keeps the first handler registered under a given name.
 
     Args:
         enable_console: When True, attach a default ``ConsoleHandler``
@@ -1063,11 +1068,17 @@ def configure(
             to the current working directory.
         scopes: Scopes under which to attach the console handler.
             Defaults to ``["global"]``.
+        name: Identifier of the console handler to replace and attach,
+            for applications that namespace their handlers (e.g.
+            ``"myapp.console"``). Defaults to the ``ConsoleHandler``
+            class default.
     """
     if not enable_console:
         return
     if scopes is None:
         scopes = ["global"]
+    if name is None:
+        name = ConsoleHandler.name
 
     # Replace any existing console handler so a second `configure(...)` call
     # with new options actually takes effect (`attach()` dedupes by name and
@@ -1078,12 +1089,13 @@ def configure(
     # handler is not attached.
     for s in scopes:
         try:
-            detach(ConsoleHandler.name, s)
+            detach(name, s)
         except ValueError:
             # Not attached here (in-process bus); nothing to detach.
             pass
 
     handler = ConsoleHandler(
+        name=name,
         level=console_level,
         path_style=console_path_style,
         project_root=Path(project_root) if project_root is not None else None,
@@ -1230,6 +1242,7 @@ __all__ = [
     "Video",
     "WandBHandler",
     "attach",
+    "configure",
     "detach",
     "filters",
     "finish",

--- a/goggles/_core/integrations/wandb.py
+++ b/goggles/_core/integrations/wandb.py
@@ -252,6 +252,7 @@ class WandBHandler:
         tags: Sequence[str] | None = None,
         reinit: Reinit = "create_new",
         wandb_init_kwargs: Mapping[str, Any] | None = None,
+        name: str = "wandb",
     ) -> None:
         """Initialize the W&B handler.
 
@@ -272,12 +273,16 @@ class WandBHandler:
                 {"finish_previous", "return_previous", "create_new", "default"}.
             wandb_init_kwargs: Additional keyword arguments forwarded to
                 ``wandb.init``.
+            name: Stable handler identifier. The event bus keys handlers
+                by it, so give each concurrently attached W&B handler a
+                distinct name.
 
         Raises:
             ValueError: If `reinit` is not a valid option, or if
                 `wandb_init_kwargs` contains invalid or handler-owned keys.
             TypeError: If `tags` is a `str` or contains non-string items.
         """
+        self.name = name
         self._logger = logging.getLogger(self.name)
         # Ensure that Goggles logs are not propagated to the root logger
         # to avoid duplicates
@@ -754,6 +759,7 @@ class WandBHandler:
         return {
             "cls": self.__class__.__name__,
             "data": {
+                "name": self.name,
                 "project": self._project,
                 "entity": self._entity,
                 "run_name": self._base_run_name,
@@ -769,6 +775,9 @@ class WandBHandler:
     def from_dict(cls, serialized: dict) -> Self:
         """De-serialize the handler from its dictionary representation.
 
+        Payloads serialized before the handler carried a name rebuild
+        with the class default.
+
         Args:
             serialized: The dictionary representation of the handler.
 
@@ -777,6 +786,7 @@ class WandBHandler:
         """
         data = serialized.get("data", serialized)
         return cls(
+            name=data.get("name", cls.name),
             project=data.get("project"),
             entity=data.get("entity"),
             run_name=data.get("run_name"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robo-goggles"
-version = "0.3.1"
+version = "0.3.2"
 authors = [
     { name = "Antonio Terpin", email = "aterpin@ethz.ch" },
     { name = "Francesco Banelli", email = "fbanelli@ethz.ch" },

--- a/tests/core/integrations/test_wandb.py
+++ b/tests/core/integrations/test_wandb.py
@@ -13,6 +13,7 @@ import wandb as _real_wandb
 from wandb.proto import wandb_internal_pb2 as pb
 from wandb.sdk.internal.datastore import DataStore
 
+import goggles as gg
 import goggles._core.integrations.wandb as wandb_module
 from goggles._core.integrations.wandb import WandBHandler
 
@@ -281,6 +282,95 @@ def test_wandb_init_kwargs_roundtrip_serialization(mock_wandb):
         reinit="create_new",
         save_code=True,
         settings={"code_dir": "."},
+    )
+
+
+def test_default_handler_name(mock_wandb):
+    """The handler keeps the default name when none is supplied.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    h = WandBHandler(project="proj")
+
+    assert h.name == "wandb", (
+        "Omitting 'name' must preserve the default handler name"
+    )
+
+
+def test_custom_handler_name(mock_wandb):
+    """The constructor stores a caller-provided handler name.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    h = WandBHandler(project="proj", name="wandb.eval")
+
+    assert h.name == "wandb.eval", (
+        "Constructor must store the custom handler name"
+    )
+
+
+def test_name_roundtrips_through_to_dict(mock_wandb):
+    """A custom name survives to_dict/from_dict serialization.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    h = WandBHandler(project="proj", name="wandb.eval")
+
+    serialized = h.to_dict()
+    restored = WandBHandler.from_dict(serialized)
+
+    assert serialized["data"]["name"] == "wandb.eval", (
+        "to_dict() must serialize the handler name"
+    )
+    assert restored.name == "wandb.eval", (
+        "from_dict() must restore the serialized handler name"
+    )
+
+
+def test_from_dict_without_name_uses_default(mock_wandb):
+    """Payloads predating the ``name`` field rebuild with the default.
+
+    Older clients attaching to a newer host ship no ``name`` key.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    restored = WandBHandler.from_dict({"project": "proj"})
+
+    assert restored.name == "wandb", (
+        "from_dict() must fall back to the default name when absent"
+    )
+
+
+def test_distinct_names_coexist_on_bus(mock_wandb):
+    """Two W&B handlers with distinct names both register on a bus.
+
+    The bus dedups handlers by name, so identically named handlers
+    would collapse into a single registration.
+
+    Args:
+        mock_wandb: Patched ``wandb`` module fixture.
+    """
+    bus = gg.EventBus()
+    train = WandBHandler(project="train", name="wandb.train")
+    evaluation = WandBHandler(project="eval", name="wandb.eval")
+
+    bus.attach([train.to_dict(), evaluation.to_dict()], scopes=["global"])
+
+    assert set(bus.handlers) == {"wandb.train", "wandb.eval"}, (
+        "Both distinctly named handlers must register on the bus"
+    )
+    assert bus.scopes["global"] == {"wandb.train", "wandb.eval"}, (
+        "Both handlers must be routed under the attached scope"
+    )
+    assert bus.handlers["wandb.train"]._project == "train", (
+        "Each registered handler must keep its own configuration"
+    )
+    assert bus.handlers["wandb.eval"]._project == "eval", (
+        "Each registered handler must keep its own configuration"
     )
 
 

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -255,6 +255,69 @@ def test_configure_replaces_existing_console_handler() -> None:
         gg.finish()
 
 
+def test_configure_is_exported_from_package_root() -> None:
+    """configure() belongs to the documented public surface."""
+    assert "configure" in gg.__all__, (
+        "configure must be listed in goggles.__all__ to be public"
+    )
+    assert callable(getattr(gg, "configure", None)), (
+        "configure must be importable from the goggles package root"
+    )
+
+
+def test_configure_uses_custom_handler_name() -> None:
+    """configure(name=...) registers the console under that name."""
+    gg.finish()
+    try:
+        gg.configure(enable_console=True, name="app.console")
+        handlers = _bus_handlers()
+        assert "app.console" in handlers, (
+            "configure(name='app.console') must register the console "
+            f"handler under that name; saw {sorted(handlers)}"
+        )
+        assert gg.ConsoleHandler.name not in handlers, (
+            "A custom name must replace the class default, not be "
+            f"registered alongside '{gg.ConsoleHandler.name}'"
+        )
+    finally:
+        gg.finish()
+
+
+def test_configure_replaces_console_handler_with_custom_name() -> None:
+    """A second configure(name=...) call swaps that named handler."""
+    gg.finish()
+    try:
+        gg.configure(
+            enable_console=True,
+            name="app.console",
+            console_level=logging.INFO,
+        )
+        first = _bus_handlers()["app.console"]
+        gg.configure(
+            enable_console=True,
+            name="app.console",
+            console_level=logging.WARNING,
+        )
+        consoles = [
+            h
+            for h in _bus_handlers().values()
+            if isinstance(h, gg.ConsoleHandler)
+        ]
+        assert len(consoles) == 1, (
+            f"Reconfigure under a custom name must keep exactly one "
+            f"console handler; saw {len(consoles)}"
+        )
+        assert consoles[0] is not first, (
+            "Reconfigure must install a new ConsoleHandler instance "
+            "under the custom name"
+        )
+        assert consoles[0].level == logging.WARNING, (
+            f"The last configure() call must win (saw {consoles[0].level})"
+        )
+    finally:
+        gg.finish()
+
+
 def test_class_level_logger_does_not_hang_on_first_info() -> None:
     """Logger captured at class-body scope must not hang on first .info().
 

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -408,6 +408,149 @@ def test_eventbus_emit_ignores_unknown_scope():
 
 
 # ---------------------------------------------------------------------
+# attach() handler-name conflicts
+# ---------------------------------------------------------------------
+
+
+class ConflictHandler:
+    """Handler whose serialized config the test controls key by key."""
+
+    name: str = "conflict"
+    capabilities: ClassVar[frozenset[gg.Kind]] = frozenset({"log"})
+
+    def __init__(self, name="conflict", level=logging.INFO, path="logs"):
+        self.name = name
+        self.level = level
+        self.path = path
+
+    def can_handle(self, kind):
+        return True
+
+    def handle(self, event):
+        pass
+
+    def open(self):
+        pass
+
+    def close(self):
+        pass
+
+    def to_dict(self):
+        return {
+            "cls": type(self).__name__,
+            "data": {
+                "name": self.name,
+                "level": self.level,
+                "path": self.path,
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, serialized):
+        return cls(**serialized)
+
+
+class OtherConflictHandler(ConflictHandler):
+    """A second handler class serializing under the same config keys."""
+
+
+def _stderr_lines(capsys) -> list[str]:
+    """Non-empty stderr lines captured so far."""
+    return [line for line in capsys.readouterr().err.splitlines() if line]
+
+
+def test_attach_identical_config_twice_is_silent(capsys) -> None:
+    """Re-attaching the very same config is the idempotent case."""
+    gg.register_handler(ConflictHandler)
+    bus = gg.EventBus()
+    handler = ConflictHandler(name="dup", level=logging.INFO)
+
+    bus.attach([handler.to_dict()], scopes=["a"])
+    bus.attach([handler.to_dict()], scopes=["a"])
+
+    assert _stderr_lines(capsys) == [], (
+        "Re-attaching an identical handler config must stay silent"
+    )
+    assert list(bus.handlers) == ["dup"], (
+        "An identical re-attach must not register a second handler"
+    )
+
+
+def test_attach_conflicting_level_warns_and_keeps_first(capsys) -> None:
+    """A differing config under a known name warns and changes nothing."""
+    gg.register_handler(ConflictHandler)
+    bus = gg.EventBus()
+    first = ConflictHandler(name="dup", level=logging.INFO)
+    second = ConflictHandler(name="dup", level=logging.DEBUG)
+
+    bus.attach([first.to_dict()], scopes=["a"])
+    bus.attach([second.to_dict()], scopes=["b"])
+
+    warnings = _stderr_lines(capsys)
+    assert len(warnings) == 1, (
+        f"Expected exactly one conflict warning, got {warnings}"
+    )
+    assert "dup" in warnings[0], "The warning must name the handler"
+    assert "level" in warnings[0], (
+        "The warning must list the config key that differs"
+    )
+    assert "path" not in warnings[0], (
+        "The warning must not list config keys that are identical"
+    )
+    assert "first" in warnings[0], (
+        "The warning must say the first registration is kept"
+    )
+    assert cast(Any, bus.handlers["dup"]).level == logging.INFO, (
+        "The first registration must stay in effect"
+    )
+    assert bus.scopes["b"] == {"dup"}, (
+        "The second attach's scopes must still be merged"
+    )
+
+
+def test_attach_different_names_same_scope_does_not_warn(capsys) -> None:
+    """Distinct names sharing a scope are not a conflict."""
+    gg.register_handler(ConflictHandler)
+    bus = gg.EventBus()
+    first = ConflictHandler(name="one", level=logging.INFO)
+    second = ConflictHandler(name="two", level=logging.DEBUG)
+
+    bus.attach([first.to_dict(), second.to_dict()], scopes=["a"])
+
+    assert _stderr_lines(capsys) == [], "Different handler names must not warn"
+    assert set(bus.handlers) == {"one", "two"}, (
+        "Both handlers should be registered under their own names"
+    )
+    assert bus.scopes["a"] == {"one", "two"}, (
+        "Both handlers should be routed under the shared scope"
+    )
+
+
+def test_attach_conflicting_class_reports_the_class(capsys) -> None:
+    """A same-named handler of another class reports the class itself."""
+    gg.register_handler(ConflictHandler)
+    gg.register_handler(OtherConflictHandler)
+    bus = gg.EventBus()
+    first = ConflictHandler(name="dup")
+    second = OtherConflictHandler(name="dup")
+
+    bus.attach([first.to_dict()], scopes=["a"])
+    bus.attach([second.to_dict()], scopes=["a"])
+
+    warnings = _stderr_lines(capsys)
+    assert len(warnings) == 1, (
+        f"Expected exactly one conflict warning, got {warnings}"
+    )
+    assert "dup" in warnings[0], "The warning must name the handler"
+    assert "class" in warnings[0], (
+        "A differing handler class must be reported as such"
+    )
+    assert type(bus.handlers["dup"]) is ConflictHandler, (
+        "The first registration must stay in effect"
+    )
+
+
+# ---------------------------------------------------------------------
 # LocalStorageHandler I/O
 # ---------------------------------------------------------------------
 

--- a/tests/core/test_dedicated_host.py
+++ b/tests/core/test_dedicated_host.py
@@ -315,6 +315,22 @@ def test_configure_replaces_console_under_dedicated_host(
         gg.finish(timeout=10.0)
 
 
+def test_configure_detaches_custom_console_name_under_dedicated_host(
+    default_host_socket: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The detach that makes the last configure() win must target the
+    # caller's handler name, not the class default -- otherwise an app that
+    # namespaces its console handler never replaces anything.
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(gg, "detach", lambda n, s: calls.append((n, s)))
+    try:
+        gg.configure(enable_console=True, name="app.console", scopes=["global"])
+        assert ("app.console", "global") in calls
+        assert (gg.ConsoleHandler.name, "global") not in calls
+    finally:
+        gg.finish(timeout=10.0)
+
+
 def test_falls_back_to_in_process_host_when_spawn_raises(
     default_host_socket: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2139,7 +2139,7 @@ wheels = [
 
 [[package]]
 name = "robo-goggles"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "imageio" },


### PR DESCRIPTION
Release **v0.3.2** to `main`, following the established milestone pattern (`Merge branch 'dev' for vX.Y.Z release`).

`main` is a strict ancestor of `dev`, so this merges cleanly with no conflicts.

## What ships in v0.3.2

**Handler identity — the theme of this release.** The event bus keys handlers by `name` alone, globally across every process sharing a socket, first-writer-wins. That contract was undocumented and unenforced, which caused duplicated console output and silently dropped handler configurations downstream.

- **`attach()` warns on a name conflict** (#228) — when a handler is dropped because its name is taken and its configuration differs, the bus now names the handler and the differing options on the host's stderr instead of failing silently. Identical re-attach stays silent (the idempotent case).
- **`WandBHandler(name=...)`** (#226) — the name was a fixed class constant, so two W&B handlers could never coexist; the second was silently dropped, project and all. Now settable and round-tripped through serialization, backward compatible with payloads that lack it.
- **`configure()` is public** (#227) — exported, documented, and able to target a custom handler name. It is the one last-call-wins setup path, which is what multi-process applications need.
- **Handler-naming documentation** (#231) — a README section plus an architecture-guide cross-reference stating that names are global application state, and every example unified onto one naming scheme (two examples previously collided under one name at different levels). Also fixes a README routing example whose claims were wrong in two ways.

**Housekeeping:** pillow bumped past its CVEs (#229, #230), a commitlint exemption unblocking CI repo-wide (#233), and the release commit itself (#234), which also backfills the `[0.3.1]` changelog section that the previous release omitted.

## Patch, not minor
Every new parameter defaults to the prior behavior and `attach()` only gained a diagnostic, so nothing existing changes semantics.

## After merge
Tag `v0.3.2` on `main` — that is what triggers `release.yaml` to build, publish to PyPI, and create the GitHub release. Not tagged here: publishing is irreversible and yours to trigger. The tag must match `pyproject.toml`, which is already at `0.3.2` (verified, along with the `uv.lock` self-entry).

**Merge with a merge commit, not a squash**, to match `ff3614c` / `53a4395` and keep per-PR history on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
