### PR TITLE
Merge branch 'dev' for v0.3.3 release

### DIFF
--- a/goggles/_core/transport/_local.py
+++ b/goggles/_core/transport/_local.py
@@ -66,6 +66,45 @@ _log = logging.getLogger(__name__)
 
 _SENTINEL = object()  # "stop draining / sending" marker
 
+
+class _AttachControl:
+    """ATTACH control op queued behind the events that preceded it.
+
+    Control frames ride ``_drain_queue`` with the event stream so they
+    take effect in the order the client sent them: applying an ATTACH or
+    DETACH directly on the reader thread would let it overtake events
+    still queued behind a slow handler.
+    """
+
+    __slots__ = ("handlers", "scopes")
+
+    def __init__(self, handlers: list[dict], scopes: list[str]) -> None:
+        """Capture one ATTACH operation.
+
+        Args:
+            handlers: Serialized handler dicts (see ``Handler.to_dict``).
+            scopes: Scopes under which to attach.
+        """
+        self.handlers = handlers
+        self.scopes = scopes
+
+
+class _DetachControl:
+    """DETACH control op queued behind the events that preceded it."""
+
+    __slots__ = ("handler_name", "scope")
+
+    def __init__(self, handler_name: str, scope: str) -> None:
+        """Capture one DETACH operation.
+
+        Args:
+            handler_name: Name of the handler to detach.
+            scope: Scope to detach from.
+        """
+        self.handler_name = handler_name
+        self.scope = scope
+
+
 _DEFAULT_HOST_IDLE_TIMEOUT_S = 5.0
 # Small delay before reaping after a clean last-client disconnect: long enough
 # that the accept loop registers (and so cancels the reap for) a client that
@@ -520,15 +559,23 @@ class LocalTransport:
         elif kind == _MSG_ATTACH:
             try:
                 handlers, scopes = pickle.loads(body)
-                self._bus.attach(handlers, scopes)
             except Exception:
-                _log.exception("Failed to handle ATTACH frame")
+                _log.exception("Failed to unpack ATTACH frame")
+                return
+            # Queued, not applied inline: an attach applied on the reader
+            # thread would overtake events still queued behind a slow
+            # handler and start routing events emitted before it.
+            self._drain_queue.put(_AttachControl(handlers, scopes))
         elif kind == _MSG_DETACH:
             try:
                 handler_name, scope = pickle.loads(body)
-                self._bus.detach(handler_name, scope)
             except Exception:
-                _log.exception("Failed to handle DETACH frame")
+                _log.exception("Failed to unpack DETACH frame")
+                return
+            # Queued, not applied inline: a detach applied on the reader
+            # thread closes the handler while events sent before it are
+            # still queued, silently dropping them once dispatched.
+            self._drain_queue.put(_DetachControl(handler_name, scope))
         elif kind == _MSG_BYE:
             # Client announced graceful disconnect; reader will hit EOF
             # after all queued frames have been consumed.
@@ -537,7 +584,7 @@ class LocalTransport:
             _log.warning("Unknown frame kind %d", kind)
 
     def _drain_loop(self) -> None:
-        """Drain queued events on the host and call ``EventBus.emit``."""
+        """Drain queued events and control ops in arrival order."""
         while True:
             item = self._drain_queue.get()
             if item is _SENTINEL:
@@ -545,6 +592,18 @@ class LocalTransport:
             if self._drain_aborted.is_set():
                 # Bounded shutdown timed out: discard the remaining queue
                 # rather than dispatching it concurrently with close().
+                continue
+            if isinstance(item, _AttachControl):
+                try:
+                    self._bus.attach(item.handlers, item.scopes)
+                except Exception:
+                    _log.exception("Failed to handle ATTACH frame")
+                continue
+            if isinstance(item, _DetachControl):
+                try:
+                    self._bus.detach(item.handler_name, item.scope)
+                except Exception:
+                    _log.exception("Failed to handle DETACH frame")
                 continue
             try:
                 self._bus.emit(item)
@@ -736,7 +795,10 @@ class LocalTransport:
             scopes: Scopes under which to attach.
         """
         if self._is_host:
-            self._bus.attach(handlers, scopes)
+            # Queued with the event stream: host-mode ``emit`` rides
+            # ``_drain_queue``, so an inline attach would overtake events
+            # emitted before it (see ``_AttachControl``).
+            self._drain_queue.put(_AttachControl(handlers, scopes))
             return
         if not self._running:
             return
@@ -751,7 +813,10 @@ class LocalTransport:
             scope: Scope to detach from.
         """
         if self._is_host:
-            self._bus.detach(handler_name, scope)
+            # Queued with the event stream: an inline detach would close
+            # the handler while events emitted before it are still queued,
+            # silently dropping them (see ``_DetachControl``).
+            self._drain_queue.put(_DetachControl(handler_name, scope))
             return
         if not self._running:
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robo-goggles"
-version = "0.3.2"
+version = "0.3.3"
 authors = [
     { name = "Antonio Terpin", email = "aterpin@ethz.ch" },
     { name = "Francesco Banelli", email = "fbanelli@ethz.ch" },

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -3,6 +3,8 @@
 import importlib
 import logging
 import threading
+import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, ClassVar, cast
 
@@ -172,6 +174,28 @@ def _bus_handlers() -> dict:
     return dict(transport._bus.handlers)
 
 
+def _settle(cond: Callable[[], bool], timeout: float = 2.0) -> bool:
+    """Poll ``cond`` until true or ``timeout`` elapses.
+
+    Attach/detach ride the transport's drain queue so they stay ordered
+    with the event stream; bus state reflects them once the queue turns,
+    not synchronously on return.
+
+    Args:
+        cond: Callable returning True once the awaited state is visible.
+        timeout: Total seconds to wait.
+
+    Returns:
+        The final value of ``cond()``.
+    """
+    end = time.monotonic() + timeout
+    while time.monotonic() < end:
+        if cond():
+            return True
+        time.sleep(0.01)
+    return cond()
+
+
 def test_configure_is_noop_by_default() -> None:
     """configure() with no args attaches nothing — purely a shortcut."""
     gg.finish()  # clean slate
@@ -190,7 +214,7 @@ def test_configure_enable_console_attaches_console_handler() -> None:
     gg.finish()
     try:
         gg.configure(enable_console=True, console_level=logging.WARNING)
-        assert "global" in _scoped_handlers(), (
+        assert _settle(lambda: "global" in _scoped_handlers()), (
             "configure(enable_console=True) should attach to 'global' by "
             "default"
         )
@@ -214,6 +238,9 @@ def test_configure_respects_scopes_argument() -> None:
     gg.finish()
     try:
         gg.configure(enable_console=True, scopes=["train", "eval"])
+        assert _settle(lambda: {"train", "eval"} <= set(_scoped_handlers())), (
+            "configure() should attach the console under both scopes"
+        )
         scopes = _scoped_handlers()
         for s in ("train", "eval"):
             assert s in scopes, (
@@ -228,12 +255,32 @@ def test_configure_replaces_existing_console_handler() -> None:
     gg.finish()
     try:
         gg.configure(enable_console=True, console_level=logging.INFO)
+        assert _settle(
+            lambda: any(
+                isinstance(h, gg.ConsoleHandler)
+                for h in _bus_handlers().values()
+            )
+        ), "First configure() should attach a console handler"
         first = next(
             h
             for h in _bus_handlers().values()
             if isinstance(h, gg.ConsoleHandler)
         )
         gg.configure(enable_console=True, console_level=logging.WARNING)
+        assert _settle(
+            lambda: any(
+                h is not first and isinstance(h, gg.ConsoleHandler)
+                for h in _bus_handlers().values()
+            )
+            and len(
+                [
+                    h
+                    for h in _bus_handlers().values()
+                    if isinstance(h, gg.ConsoleHandler)
+                ]
+            )
+            == 1
+        ), "Reconfigure should swap in a new console handler"
         consoles = [
             h
             for h in _bus_handlers().values()
@@ -270,6 +317,9 @@ def test_configure_uses_custom_handler_name() -> None:
     gg.finish()
     try:
         gg.configure(enable_console=True, name="app.console")
+        assert _settle(lambda: "app.console" in _bus_handlers()), (
+            "configure(name=...) should attach under the custom name"
+        )
         handlers = _bus_handlers()
         assert "app.console" in handlers, (
             "configure(name='app.console') must register the console "
@@ -292,12 +342,21 @@ def test_configure_replaces_console_handler_with_custom_name() -> None:
             name="app.console",
             console_level=logging.INFO,
         )
+        assert _settle(lambda: "app.console" in _bus_handlers()), (
+            "First configure(name=...) should attach under the custom name"
+        )
         first = _bus_handlers()["app.console"]
         gg.configure(
             enable_console=True,
             name="app.console",
             console_level=logging.WARNING,
         )
+        assert _settle(
+            lambda: (
+                (h := _bus_handlers().get("app.console")) is not None
+                and h is not first
+            )
+        ), "Reconfigure should swap the handler under the custom name"
         consoles = [
             h
             for h in _bus_handlers().values()

--- a/tests/core/test_transport.py
+++ b/tests/core/test_transport.py
@@ -328,6 +328,11 @@ def test_host_mode_emit_dispatches_to_handler(socket_path: str) -> None:
         transport.attach(
             handlers=[_CollectingHandler().to_dict()], scopes=["global"]
         )
+        # Attach rides the drain queue so it stays ordered with events
+        # emitted before it; the bus reflects it once the queue turns.
+        assert _wait_until(
+            lambda: "collector" in transport._bus.handlers  # type: ignore[attr-defined]
+        ), "host-mode attach should install the handler via the drain queue"
         collector = cast(
             _CollectingHandler,
             transport._bus.handlers["collector"],  # type: ignore[attr-defined]
@@ -975,6 +980,82 @@ def test_client_attach_and_detach_control_frames(socket_path: str) -> None:
             client.shutdown(timeout=2.0)
     finally:
         host.shutdown(timeout=2.0)
+
+
+class _SlowCollectingHandler(_CollectingHandler):
+    """Collector whose ``handle`` stalls, backing up the host drain queue."""
+
+    name = "slow-collector"
+
+    def handle(self, event: Event) -> None:
+        time.sleep(0.05)
+        super().handle(event)
+
+    def to_dict(self) -> dict:
+        return {"cls": "_SlowCollectingHandler", "data": {}}
+
+
+def test_detach_applies_after_previously_emitted_events(
+    socket_path: str,
+) -> None:
+    """A detach never overtakes events the same client emitted before it.
+
+    Regresses silent event loss at shutdown: DETACH used to be applied
+    inline on the reader thread while data events queued behind a slow
+    handler, so the handler was removed before those events were
+    dispatched and they vanished without a warning -- in production,
+    everything a run logged in its last seconds before detaching its
+    W&B handler.
+
+    Args:
+        socket_path: Endpoint path (via fixture).
+    """
+    gg.register_handler(_SlowCollectingHandler)
+    host = LocalTransport(socket_path=socket_path)
+    try:
+        client = LocalTransport(socket_path=socket_path)
+        try:
+            bus = host._bus  # type: ignore[attr-defined]
+            client.attach(
+                handlers=[_SlowCollectingHandler().to_dict()],
+                scopes=["global"],
+            )
+            assert _wait_until(lambda: "slow-collector" in bus.handlers), (
+                "client ATTACH should install the slow handler on host"
+            )
+            collector = cast(
+                _SlowCollectingHandler, bus.handlers["slow-collector"]
+            )
+
+            n_events = 20
+            for i in range(n_events):
+                client.emit(
+                    Event(
+                        kind="log",
+                        scope="global",
+                        payload=f"event-{i}",
+                        filepath="t.py",
+                        lineno=i,
+                    )
+                )
+            # The slow handler guarantees most events are still queued on
+            # the host when the detach frame arrives right behind them.
+            client.detach("slow-collector", "global")
+
+            assert _wait_until(
+                lambda: "slow-collector" not in bus.handlers,
+                timeout=n_events * 0.05 + 5.0,
+            ), "client DETACH should eventually remove the slow handler"
+            with collector.lock:
+                got = [e.payload for e in collector.events]
+            assert got == [f"event-{i}" for i in range(n_events)], (
+                f"Every event emitted before the detach must be handled "
+                f"before it applies; got {len(got)} of {n_events}: {got}"
+            )
+        finally:
+            client.shutdown(timeout=5.0)
+    finally:
+        host.shutdown(timeout=5.0)
 
 
 def test_shutdown_flushes_pending_events(socket_path: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -702,11 +702,11 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "ml-dtypes" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "opt-einsum" },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "opt-einsum", marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/1e/267f59c8fb7f143c3f778c76cb7ef1389db3fd7e4540f04b9f42ca90764d/jax-0.6.2.tar.gz", hash = "sha256:a437d29038cbc8300334119692744704ca7941490867b9665406b7f90665cd96", size = 2334091, upload-time = "2025-06-17T23:10:27.186Z" }
 wheels = [
@@ -736,11 +736,11 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.9.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "ml-dtypes" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "opt-einsum" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "jaxlib", version = "0.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "opt-einsum", marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/39/28/13186d20cbece4944577de774269c620b2f5f5ea163748b61e48e423f47f/jax-0.9.0.tar.gz", hash = "sha256:e5ce9d6991333aeaad37729dd8315d29c4b094ea9476a32fb49933b556c723fb", size = 2534495, upload-time = "2026-01-20T23:06:47.099Z" }
 wheels = [
@@ -756,9 +756,9 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "ml-dtypes" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/c5/41598634c99cbebba46e6777286fb76abc449d33d50aeae5d36128ca8803/jaxlib-0.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4601b2b5dc8c23d6afb293eacfb9aec4e1d1871cb2f29c5a151d103e73b0f8", size = 54298019, upload-time = "2025-06-17T23:10:36.916Z" },
@@ -804,9 +804,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "ml-dtypes" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/71/283ee038a94869e7b3b3a27a594c028a58692e69f338bc30d0a466711830/jaxlib-0.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2770e2250e7923111f5e28813e593492fde3df40185b50bdc8bc41b866b99a8e", size = 56091849, upload-time = "2026-01-20T22:28:06.682Z" },
@@ -1432,10 +1432,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -1511,9 +1511,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -2139,7 +2139,7 @@ wheels = [
 
 [[package]]
 name = "robo-goggles"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "imageio" },
@@ -2281,7 +2281,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c", size = 57210720, upload-time = "2024-05-23T03:29:26.079Z" }
 wheels = [
@@ -2328,7 +2328,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/3e/9cca699f3486ce6bc12ff46dc2031f1ec8eb9ccc9a320fdaf925f1417426/scipy-1.17.0.tar.gz", hash = "sha256:2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e", size = 30396830, upload-time = "2026-01-10T21:34:23.009Z" }
 wheels = [


### PR DESCRIPTION
Release v0.3.3: transport-level ordering fix for ATTACH/DETACH control frames (#238) — a detach no longer overtakes events the same client emitted before it, closing a silent event-loss path at handler detach under slow-handler backlogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnyY1MCaLXa8G5x8LYgfXS