### PR TITLE
fix(routing): atexit backstop no-ops after an explicit finish() (v0.3.4)

### DIFF
--- a/goggles/__init__.py
+++ b/goggles/__init__.py
@@ -1262,9 +1262,15 @@ def finish(timeout: float | None = None) -> None:
     # handlers (e.g. finishing W&B runs); wait so the usual "everything is
     # delivered + finalized once finish() returns" guarantee still holds. No-op
     # when other processes keep the host alive.
-    from ._core.routing import _await_host_finalize  # noqa: PLC0415
+    from ._core.routing import (  # noqa: PLC0415
+        _await_host_finalize,
+        _mark_finished,
+    )
 
     _await_host_finalize(timeout)
+    # The atexit backstop has nothing left to guarantee: the transport is
+    # flushed and the host wait above ran with the caller's own timeout.
+    _mark_finished()
 
 
 def register_handler(handler_class: type) -> None:

--- a/goggles/_core/routing.py
+++ b/goggles/_core/routing.py
@@ -51,6 +51,11 @@ __host_proc: subprocess.Popen | None = None
 __host_lock = threading.Lock()
 __atexit_registered = False
 
+# Set by :func:`goggles.finish` once it has flushed the transport and waited
+# for the host within the caller's own timeout; the atexit backstop then has
+# nothing left to guarantee and must not wait again.
+__finish_completed = False
+
 _DEDICATED_HOST_ENV = "GOGGLES_DEDICATED_HOST"
 # How long to wait for a freshly spawned host to bind + signal readiness
 # before falling back to an in-process host. Binding is normally well under a
@@ -86,7 +91,7 @@ def get_bus() -> Transport:
     Returns:
         The singleton transport.
     """
-    global __singleton_transport  # noqa: PLW0603
+    global __singleton_transport, __finish_completed  # noqa: PLW0603
     current = __singleton_transport
     if current is None or not current.is_running:
         from goggles._core.transport import LocalTransport  # noqa: PLC0415
@@ -94,6 +99,9 @@ def get_bus() -> Transport:
         _spawn_dedicated_host()
         current = LocalTransport()
         __singleton_transport = current
+        # New transport, new activity: the atexit backstop is armed again
+        # until the next explicit finish().
+        __finish_completed = False
     return current
 
 
@@ -103,8 +111,9 @@ def reset_bus() -> None:
     Intended for tests and long-running processes that need to rebuild
     the transport after :meth:`Transport.shutdown` has been called.
     """
-    global __singleton_transport  # noqa: PLW0603
+    global __singleton_transport, __finish_completed  # noqa: PLW0603
     __singleton_transport = None
+    __finish_completed = False
 
 
 # ----- dedicated host process ---------------------------------------------
@@ -392,6 +401,18 @@ def _await_host_finalize(timeout: float | None) -> None:
         pass
 
 
+def _mark_finished() -> None:
+    """Record that an explicit ``finish()`` completed.
+
+    The atexit backstop exists for programs that exit without calling
+    ``finish()``; once ``finish()`` has run, it already flushed the
+    transport and waited for the host within the caller's chosen
+    timeout, so the backstop must not wait again on interpreter exit.
+    """
+    global __finish_completed  # noqa: PLW0603
+    __finish_completed = True
+
+
 def _atexit_terminate_host() -> None:
     """``atexit`` backstop: flush this process's transport on interpreter exit.
 
@@ -402,6 +423,8 @@ def _atexit_terminate_host() -> None:
     so a sibling process still logging keeps its host. No-op once ``finish()``
     has run. Bounded so interpreter shutdown never hangs.
     """
+    if __finish_completed:
+        return
     transport = __singleton_transport
     if transport is not None and transport.is_running:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robo-goggles"
-version = "0.3.3"
+version = "0.3.4"
 authors = [
     { name = "Antonio Terpin", email = "aterpin@ethz.ch" },
     { name = "Francesco Banelli", email = "fbanelli@ethz.ch" },

--- a/tests/core/test_dedicated_host.py
+++ b/tests/core/test_dedicated_host.py
@@ -535,3 +535,58 @@ def test_kill_reaps_a_live_process() -> None:
     assert proc.poll() is not None
     # Calling again on an already-dead process is a safe no-op.
     routing._kill(proc)
+
+
+def test_atexit_backstop_is_a_noop_after_finish(
+    default_host_socket: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After an explicit ``finish()``, interpreter exit must not wait again.
+
+    ``finish()`` flushes the transport and waits for the host within the
+    caller's own timeout. The atexit backstop used to run its bounded
+    ``_await_host_finalize`` afterwards anyway, serializing up to
+    ``_HOST_ATEXIT_TIMEOUT_S`` of the host's background drain into every
+    process exit that had already finished cleanly.
+    """
+    gg.get_bus()
+    gg.finish(timeout=10.0)
+
+    waits: list[float | None] = []
+    monkeypatch.setattr(
+        routing, "_await_host_finalize", lambda timeout: waits.append(timeout)
+    )
+    routing._atexit_terminate_host()
+
+    assert waits == [], (
+        "The atexit backstop must not wait for the host again after an "
+        f"explicit finish(); waited with timeouts {waits}"
+    )
+
+
+def test_atexit_backstop_arms_again_after_a_new_transport(
+    default_host_socket: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transport built after ``finish()`` re-arms the atexit backstop.
+
+    A program that finishes and then resumes logging gets a fresh
+    transport; exiting without a second ``finish()`` must again flush and
+    wait, or the resumed activity could be dropped on interpreter exit.
+    """
+    gg.get_bus()
+    gg.finish(timeout=10.0)
+    bus = gg.get_bus()
+    try:
+        waits: list[float | None] = []
+        monkeypatch.setattr(
+            routing,
+            "_await_host_finalize",
+            lambda timeout: waits.append(timeout),
+        )
+        routing._atexit_terminate_host()
+
+        assert waits == [routing._HOST_ATEXIT_TIMEOUT_S], (
+            "A fresh transport after finish() must re-arm the backstop, "
+            f"got waits {waits}"
+        )
+    finally:
+        bus.shutdown(timeout=10.0)

--- a/uv.lock
+++ b/uv.lock
@@ -2139,7 +2139,7 @@ wheels = [
 
 [[package]]
 name = "robo-goggles"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "imageio" },


### PR DESCRIPTION
## Problem

`_atexit_terminate_host`'s docstring says "No-op once `finish()` has run", but the implementation only skipped the transport shutdown half: `_await_host_finalize(_HOST_ATEXIT_TIMEOUT_S)` still ran unconditionally on interpreter exit. When the exiting process was the host's last client, the host has already begun winding down (socket unlinked), so the backstop `proc.wait(30)`s on a host that is deliberately finishing its drain (e.g. online W&B runs) in the background. A short-lived process that called `finish(timeout=...)` — bounding its own willingness to wait — then paid up to 30 more seconds at exit, serializing the host's background sync into every process lifetime.

## Change

- `finish()` records completion (`_mark_finished()` in routing) after its own flush + host wait; the atexit backstop returns immediately once that flag is set — honoring the documented contract.
- Building a fresh transport (`get_bus()` recreating after shutdown, or `reset_bus()`) clears the flag, so a program that resumes logging after `finish()` keeps the exit-time flush guarantee.
- Regression tests: the backstop performs no host wait after an explicit `finish()` (fails on the previous behavior), and re-arms after a new transport is built.
- Version: 0.3.3 → 0.3.4.

## Validation

Full suite: 724 passed, 4 skipped (`uv run --all-extras pytest tests/`). Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnyY1MCaLXa8G5x8LYgfXS