### PR TITLE
feat(api): finish(wait_for_host=False) returns at the end of the handoff (v0.3.5)

### DIFF
--- a/goggles/__init__.py
+++ b/goggles/__init__.py
@@ -1225,7 +1225,7 @@ def detach(handler_name: str, scope: str) -> None:
     bus.detach(handler_name, scope)
 
 
-def finish(timeout: float | None = None) -> None:
+def finish(timeout: float | None = None, *, wait_for_host: bool = True) -> None:
     """Shutdown the global transport and close all handlers.
 
     Default behavior is to wait indefinitely so no queued events are
@@ -1240,6 +1240,14 @@ def finish(timeout: float | None = None) -> None:
             If ``None``, falls back to the ``GOGGLES_SHUTDOWN_TIMEOUT``
             env var; an unset env var or a non-positive value means no
             deadline.
+        wait_for_host: If True, additionally wait for a dedicated host
+            this process spawned to finalize its handlers once it reaps
+            (the "everything is delivered and finalized once finish()
+            returns" guarantee). If False, return as soon as this
+            process's own queue has fully drained to the host — an exact,
+            naturally terminating handoff — and leave the host to
+            dispatch and finalize on its own schedule; it outlives this
+            process and completes the same work either way.
     """
     bus = get_bus()
     if timeout is None:
@@ -1267,9 +1275,11 @@ def finish(timeout: float | None = None) -> None:
         _mark_finished,
     )
 
-    _await_host_finalize(timeout)
+    if wait_for_host:
+        _await_host_finalize(timeout)
     # The atexit backstop has nothing left to guarantee: the transport is
-    # flushed and the host wait above ran with the caller's own timeout.
+    # flushed, and the host wait either ran with the caller's own timeout
+    # or was explicitly declined.
     _mark_finished()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robo-goggles"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
     { name = "Antonio Terpin", email = "aterpin@ethz.ch" },
     { name = "Francesco Banelli", email = "fbanelli@ethz.ch" },

--- a/tests/core/test_dedicated_host.py
+++ b/tests/core/test_dedicated_host.py
@@ -590,3 +590,50 @@ def test_atexit_backstop_arms_again_after_a_new_transport(
         )
     finally:
         bus.shutdown(timeout=10.0)
+
+
+def test_finish_without_host_wait_skips_the_finalize_wait(
+    default_host_socket: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``finish(wait_for_host=False)`` returns at the end of the handoff.
+
+    The local queue drain has an exact, naturally terminating end; the
+    host outlives this process and finalizes its handlers on its own
+    schedule, so a caller that needs no sync guarantee must not pay for
+    the host's (online-latency-bound) wind-down.
+    """
+    gg.get_bus()
+    waits: list[float | None] = []
+    monkeypatch.setattr(
+        routing, "_await_host_finalize", lambda timeout: waits.append(timeout)
+    )
+
+    gg.finish(wait_for_host=False)
+
+    assert waits == [], (
+        f"finish(wait_for_host=False) must not wait for the host, "
+        f"waited with timeouts {waits}"
+    )
+    routing._atexit_terminate_host()
+    assert waits == [], (
+        "Declining the host wait still counts as an explicit finish; the "
+        f"atexit backstop must not wait either, got {waits}"
+    )
+
+
+def test_finish_waits_for_the_host_by_default(
+    default_host_socket: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Plain ``finish()`` keeps the delivered-and-finalized guarantee."""
+    gg.get_bus()
+    waits: list[float | None] = []
+    monkeypatch.setattr(
+        routing, "_await_host_finalize", lambda timeout: waits.append(timeout)
+    )
+
+    gg.finish(timeout=10.0)
+
+    assert waits == [10.0], (
+        f"Default finish() must wait for the host with its own timeout, "
+        f"got {waits}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2139,7 +2139,7 @@ wheels = [
 
 [[package]]
 name = "robo-goggles"
-version = "0.3.4"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "imageio" },


### PR DESCRIPTION
## Problem

`finish()` conflates two waits with different characters. The local drain — this process's queue flushing to the host socket — has an exact, naturally terminating end: once the send thread pushes the last frame, the process holds no data. The host-finalize wait that follows provides the "everything delivered *and finalized* once finish() returns" guarantee, and its duration is bound by the host's handler work — for online W&B finalization, tens of seconds and load-dependent. A short-lived worker whose host deliberately outlives it (the dedicated-host design) has no use for the second wait, but could only avoid it by passing a guessed `timeout` that also (needlessly) bounds the exact, fast drain.

## Change

- `finish(wait_for_host: bool = True)` (keyword-only): with `False`, the local queue drains completely and the host-finalize wait is skipped; the host dispatches and finalizes on its own schedule, doing identical work either way. Default semantics unchanged.
- Declining the wait still counts as an explicit finish: the atexit backstop (no-op after finish since 0.3.4) stays disarmed, so process exit adds no hidden wait.
- Tests: `wait_for_host=False` performs no host wait and keeps the backstop disarmed; default `finish()` still waits with the caller's timeout.
- Version: 0.3.4 → 0.3.5.

## Validation

Full suite: 726 passed, 4 skipped (`uv run --all-extras pytest tests/`). Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnyY1MCaLXa8G5x8LYgfXS