### PR TITLE
fix(routing): no transport resurrection during interpreter finalization

### DIFF
--- a/goggles/_core/routing.py
+++ b/goggles/_core/routing.py
@@ -94,6 +94,13 @@ def get_bus() -> Transport:
     global __singleton_transport, __finish_completed  # noqa: PLW0603
     current = __singleton_transport
     if current is None or not current.is_running:
+        # No resurrection while the interpreter is shutting down: stray
+        # emits from other modules' atexit handlers (their emit() no-ops on
+        # a dead transport) must not rebuild the transport, reconnect to a
+        # winding-down host, and re-arm the backstop a completed finish()
+        # disarmed.
+        if current is not None and sys.is_finalizing():
+            return current
         from goggles._core.transport import LocalTransport  # noqa: PLC0415
 
         _spawn_dedicated_host()

--- a/tests/core/test_dedicated_host.py
+++ b/tests/core/test_dedicated_host.py
@@ -637,3 +637,38 @@ def test_finish_waits_for_the_host_by_default(
         f"Default finish() must wait for the host with its own timeout, "
         f"got {waits}"
     )
+
+
+def test_get_bus_does_not_resurrect_during_interpreter_finalization(
+    default_host_socket: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stray atexit-time emit must not rebuild the transport.
+
+    After ``finish()``, an emit from another module's atexit handler
+    (e.g. a node logging in its own shutdown hook) calls ``get_bus()``
+    on a dead singleton. Rebuilding it would reconnect to the
+    winding-down host and re-arm the backstop that finish() disarmed --
+    serializing the host's whole background drain into interpreter
+    exit. The dead transport is returned instead; its ``emit`` no-ops.
+    """
+    bus = gg.get_bus()
+    gg.finish(wait_for_host=False)
+    monkeypatch.setattr(routing.sys, "is_finalizing", lambda: True)
+
+    resurrected = gg.get_bus()
+
+    assert resurrected is bus, (
+        "get_bus() during interpreter finalization must return the dead "
+        "singleton, not build a new transport"
+    )
+    assert not resurrected.is_running, (
+        "The returned transport must stay shut down so emits no-op"
+    )
+    waits: list[float | None] = []
+    monkeypatch.setattr(
+        routing, "_await_host_finalize", lambda timeout: waits.append(timeout)
+    )
+    routing._atexit_terminate_host()
+    assert waits == [], (
+        f"The backstop must stay disarmed after finish(), got {waits}"
+    )


### PR DESCRIPTION
Completes #243 — without this, `finish(wait_for_host=False)` measurably fails to deliver: an atexit-time emit from another module (a node logging in its own shutdown hook) hits `get_bus()` on the dead singleton, which rebuilds the transport, reconnects to the still-winding-down host, and resets the finished flag — so the atexit backstop waits for the host's whole background drain anyway (~24 s observed; faulthandler stack pinned it in `_atexit_terminate_host → _await_host_finalize → proc.wait`).

`get_bus()` now returns the dead singleton while `sys.is_finalizing()`; its `emit()` already no-ops on a shut-down transport, so late atexit chatter is dropped instead of resurrecting the machinery. Normal (pre-finalization) resume after `finish()` is unchanged and still re-arms the backstop. Regression test included. No version change — this belongs in the 0.3.5 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnyY1MCaLXa8G5x8LYgfXS