### PR TITLE
fix: resolve conflict markers committed in the main merge-back

### DIFF
--- a/goggles/__init__.py
+++ b/goggles/__init__.py
@@ -1275,17 +1275,11 @@ def finish(timeout: float | None = None, *, wait_for_host: bool = True) -> None:
         _mark_finished,
     )
 
-<<<<<<< HEAD
     if wait_for_host:
         _await_host_finalize(timeout)
     # The atexit backstop has nothing left to guarantee: the transport is
     # flushed, and the host wait either ran with the caller's own timeout
     # or was explicitly declined.
-=======
-    _await_host_finalize(timeout)
-    # The atexit backstop has nothing left to guarantee: the transport is
-    # flushed and the host wait above ran with the caller's own timeout.
->>>>>>> origin/main
     _mark_finished()
 
 

--- a/tests/core/test_dedicated_host.py
+++ b/tests/core/test_dedicated_host.py
@@ -590,7 +590,6 @@ def test_atexit_backstop_arms_again_after_a_new_transport(
         )
     finally:
         bus.shutdown(timeout=10.0)
-<<<<<<< HEAD
 
 
 def test_finish_without_host_wait_skips_the_finalize_wait(
@@ -673,5 +672,3 @@ def test_get_bus_does_not_resurrect_during_interpreter_finalization(
     assert waits == [], (
         f"The backstop must stay disarmed after finish(), got {waits}"
     )
-=======
->>>>>>> origin/main


### PR DESCRIPTION
#245 committed unresolved conflict markers in `goggles/__init__.py` and `tests/core/test_dedicated_host.py` (my fault — the resolution step checked out only `pyproject.toml`/`uv.lock` and missed these). Restores both to dev's pre-merge state, which already subsumes main's side. Suite green on the affected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnyY1MCaLXa8G5x8LYgfXS