### PR TITLE
fix(routing): block transport rebuilds once interpreter exit begins (v0.3.6)

### DIFF
--- a/goggles/_core/routing.py
+++ b/goggles/_core/routing.py
@@ -56,6 +56,12 @@ __atexit_registered = False
 # nothing left to guarantee and must not wait again.
 __finish_completed = False
 
+# Set when interpreter-exit processing has begun. ``sys.is_finalizing`` is
+# False while atexit handlers run, so goggles marks the phase itself: a
+# no-op hook registered at finish() time runs ahead of hooks registered
+# earlier in the program's life (atexit is LIFO) and flips this flag.
+__exit_phase = False
+
 _DEDICATED_HOST_ENV = "GOGGLES_DEDICATED_HOST"
 # How long to wait for a freshly spawned host to bind + signal readiness
 # before falling back to an in-process host. Binding is normally well under a
@@ -94,12 +100,14 @@ def get_bus() -> Transport:
     global __singleton_transport, __finish_completed  # noqa: PLW0603
     current = __singleton_transport
     if current is None or not current.is_running:
-        # No resurrection while the interpreter is shutting down: stray
-        # emits from other modules' atexit handlers (their emit() no-ops on
-        # a dead transport) must not rebuild the transport, reconnect to a
-        # winding-down host, and re-arm the backstop a completed finish()
-        # disarmed.
-        if current is not None and sys.is_finalizing():
+        # No rebuild once interpreter-exit processing has begun: a stray
+        # emit from another module's atexit handler (a node logging in its
+        # shutdown hook) must not rebuild the transport, reconnect to the
+        # winding-down host, and re-arm the backstop that finish()
+        # disarmed. ``sys.is_finalizing`` alone misses the atexit window,
+        # hence the finish()-registered ``__exit_phase`` marker. Runtime
+        # resume after finish() (before exit) still rebuilds normally.
+        if current is not None and (__exit_phase or sys.is_finalizing()):
             return current
         from goggles._core.transport import LocalTransport  # noqa: PLC0415
 
@@ -118,9 +126,10 @@ def reset_bus() -> None:
     Intended for tests and long-running processes that need to rebuild
     the transport after :meth:`Transport.shutdown` has been called.
     """
-    global __singleton_transport, __finish_completed  # noqa: PLW0603
+    global __singleton_transport, __finish_completed, __exit_phase  # noqa: PLW0603
     __singleton_transport = None
     __finish_completed = False
+    __exit_phase = False
 
 
 # ----- dedicated host process ---------------------------------------------
@@ -408,6 +417,17 @@ def _await_host_finalize(timeout: float | None) -> None:
         pass
 
 
+def _enter_exit_phase() -> None:
+    """Record that interpreter-exit processing has begun.
+
+    Registered by :func:`_mark_finished` so it runs ahead of atexit hooks
+    registered earlier in the program's life; from this point ``get_bus``
+    returns the dead singleton instead of rebuilding.
+    """
+    global __exit_phase  # noqa: PLW0603
+    __exit_phase = True
+
+
 def _mark_finished() -> None:
     """Record that an explicit ``finish()`` completed.
 
@@ -418,6 +438,10 @@ def _mark_finished() -> None:
     """
     global __finish_completed  # noqa: PLW0603
     __finish_completed = True
+    # LIFO: registering at finish() time places this ahead of atexit hooks
+    # registered earlier (node shutdown hooks that may log); repeated
+    # registration is harmless.
+    atexit.register(_enter_exit_phase)
 
 
 def _atexit_terminate_host() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robo-goggles"
-version = "0.3.5"
+version = "0.3.6"
 authors = [
     { name = "Antonio Terpin", email = "aterpin@ethz.ch" },
     { name = "Francesco Banelli", email = "fbanelli@ethz.ch" },

--- a/tests/core/test_dedicated_host.py
+++ b/tests/core/test_dedicated_host.py
@@ -672,3 +672,42 @@ def test_get_bus_does_not_resurrect_during_interpreter_finalization(
     assert waits == [], (
         f"The backstop must stay disarmed after finish(), got {waits}"
     )
+
+
+def test_get_bus_does_not_rebuild_once_exit_phase_begins(
+    default_host_socket: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stray atexit-time emit must not rebuild the transport.
+
+    Atexit handlers run before ``sys.is_finalizing()`` turns true, so an
+    emit from another module's shutdown hook (a node logging in its
+    atexit-registered shutdown) reaches ``get_bus()`` on the dead
+    singleton in a window indistinguishable from normal runtime.
+    ``finish()`` therefore registers an exit-phase marker that, thanks to
+    atexit's LIFO order, runs ahead of hooks registered earlier in the
+    program's life; from then on the dead transport is returned (its
+    ``emit`` no-ops) instead of reconnecting to the winding-down host and
+    re-arming the backstop. Regresses a measured ~23 s interpreter-exit
+    stall in ``_atexit_terminate_host``.
+    """
+    bus = gg.get_bus()
+    gg.finish(wait_for_host=False)
+    routing._enter_exit_phase()
+
+    resurrected = gg.get_bus()
+
+    assert resurrected is bus, (
+        "get_bus() in the exit phase must return the dead singleton, not "
+        "build a new transport"
+    )
+    assert not resurrected.is_running, (
+        "The returned transport must stay shut down so emits no-op"
+    )
+    waits: list[float | None] = []
+    monkeypatch.setattr(
+        routing, "_await_host_finalize", lambda timeout: waits.append(timeout)
+    )
+    routing._atexit_terminate_host()
+    assert waits == [], (
+        f"The backstop must stay disarmed after finish(), got {waits}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2139,7 +2139,7 @@ wheels = [
 
 [[package]]
 name = "robo-goggles"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "imageio" },


### PR DESCRIPTION
## Problem

0.3.5's resurrection guard keyed on `sys.is_finalizing()` — which is **False while atexit handlers run** (verified empirically), i.e. precisely the window where the resurrection happens: another module's atexit-registered shutdown hook logs, `get_bus()` finds the dead singleton, rebuilds the transport, reconnects to the winding-down host, and re-arms the backstop `finish()` disarmed. Faulthandler-pinned cost: ~23 s of interpreter-exit stall in `_atexit_terminate_host → _await_host_finalize → proc.wait`, making `finish(wait_for_host=False)` moot in practice.

A blunt "finish() is final" rule was tried and rejected: it breaks legitimate runtime resume (`finish()` then `configure()`/log in the same process — the notebook pattern the api tests pin).

## Change

- `finish()` (via `_mark_finished`) registers an exit-phase marker hook; atexit's LIFO order runs it ahead of hooks registered earlier in the program's life (node shutdown hooks), flipping `__exit_phase`.
- `get_bus()` on a dead singleton returns it unchanged when `__exit_phase or sys.is_finalizing()` — emits no-op, nothing is rebuilt, the backstop stays disarmed. Before exit, resume-after-finish rebuilds exactly as before.
- `reset_bus()` clears the phase (deliberate restarts, tests).
- Regression test simulates the marker firing and asserts no rebuild and a disarmed backstop.
- Version: 0.3.5 → 0.3.6.

## Validation

Full suite: 728 passed, 4 skipped. Pre-commit clean. The api resume-pattern tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnyY1MCaLXa8G5x8LYgfXS